### PR TITLE
Fix OIDC module's allowed branches, disable by default

### DIFF
--- a/infra/frontend/live/stage/oidc/terragrunt.hcl
+++ b/infra/frontend/live/stage/oidc/terragrunt.hcl
@@ -21,7 +21,7 @@ include "common" {
 # Configure the version of the module to use in this environment. This allows you to promote new versions one
 # environment at a time (e.g., qa -> stage -> prod).
 terraform {
-  source = "${include.common.locals.base_source_url}?ref=v0.1.0-beta.0"
+  source = "${include.common.locals.base_source_url}?ref=v0.1.0-beta.3"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/infra/frontend/modules/oidc/main.tf
+++ b/infra/frontend/modules/oidc/main.tf
@@ -6,6 +6,8 @@ module "oidc_github" {
   iam_role_inline_policies = {
     "tg_policy" : data.aws_iam_policy_document.iam_policy.json
   }
+  enabled = var.enable_resource_creation
+  create_oidc_provider = var.enable_oidc_provider_creation
 }
 
 data "aws_iam_policy_document" "iam_policy" {

--- a/infra/frontend/modules/oidc/main.tf
+++ b/infra/frontend/modules/oidc/main.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "self" {}
+
 module "oidc_github" {
   source              = "git::https://github.com/unfunco/terraform-aws-oidc-github.git?ref=f664e8f6002b11b5c206f1fb3cf0377ea6a033ae"
   github_repositories = var.allowed_repos_branches

--- a/infra/frontend/modules/oidc/variables.tf
+++ b/infra/frontend/modules/oidc/variables.tf
@@ -1,5 +1,15 @@
 variable "allowed_repos_branches" {
   description = "GitHub repos/branches allowed to assume the IAM role."
   type        = list(string)
-  default     = ["nestrr/flock-infra:ref:refs/heads/main"]
+  default     = ["nestrr/flock-infra"]
+}
+variable "enable_resource_creation" {
+  description = "Whether the oidc module is allowed to create resources"
+  type = bool
+  default = false
+}
+variable "enable_oidc_provider_creation" {
+  description = "Whether the oidc module is allowed to create provider"
+  type = bool
+  default = false
 }


### PR DESCRIPTION
Currently the OIDC AWS module only grants access to the `main` branch in this repository. This PR expands access to all other branches too. Additionally, it disables the module by default so it does not have to manually be excluded later.