### PR TITLE
Fix resource ARN glob

### DIFF
--- a/infra/frontend/modules/oidc/main.tf
+++ b/infra/frontend/modules/oidc/main.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "iam_policy" {
       "dynamodb:*"
     ]
     resources = [
-      "arn:aws:dynamodb:*:*:table/terragrunt*"
+      "arn:aws:dynamodb:*:*:table/tf-locks*"
     ]
   }
   statement {


### PR DESCRIPTION
This PR fixes the glob in the first statement within the IAM policy assigned to the temporary OIDC role that GitHub Actions uses. It renames the table to match the name set up by the root module.