### PR TITLE
Create workflow for Terragrunt infrastructure deployments

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -28,7 +28,7 @@ env:
   TF_VERSION: '1.10.5'
   ENVIRONMENT: ${{ inputs.environment }}
   LAYER: ${{ inputs.layer }}
-  TERRAGRUNT_EXCLUDE_DIR: "infra/frontend/modules/oidc"
+  TERRAGRUNT_EXCLUDE_DIR: "**/*/oidc"
   TERRAGRUNT_NON_INTERACTIVE: true
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   TG_BUCKET_PREFIX: ${{ secrets[format('TG_S3_{0}_{1}', inputs.layer, inputs.environment)] }}
@@ -52,6 +52,7 @@ jobs:
           tg_version: ${{ env.TG_VERSION }}
           tf_version: ${{ env.TF_VERSION }}
           tg_comment: true
+          tg_dir: ${{ env.TG_DIR }}
           tg_command: 'run-all plan'
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -41,7 +41,9 @@ jobs:
     steps:
       - id: echo_bucket
         name: Provide the name of the Actions secret that stores the appropriate S3 bucket
-        run: echo "bucket=${{ secrets[format('TG_S3_{0}_{1}', env.ENVIRONMENT, env.LAYER)] }}" >> "$GITHUB_OUTPUT"
+        run: | 
+          echo "${{ format('TG_S3_{0}_{1}', env.ENVIRONMENT, env.LAYER) }}"
+          echo "bucket=${{ secrets[format('TG_S3_{0}_{1}', env.ENVIRONMENT, env.LAYER)] }}" >> "$GITHUB_OUTPUT"
   plan:
     runs-on: ubuntu-latest
     needs: [ determine_config ]

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -32,7 +32,7 @@ env:
   TERRAGRUNT_EXCLUDE_DIR: "infra/frontend/modules/oidc"
   TERRAGRUNT_NON_INTERACTIVE: true
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  TG_BUCKET_PREFIX: ${{ secrets[format('TG_S3_{0}_{1}', env.LAYER, env.ENVIRONMENT)] }}
+  TG_BUCKET_PREFIX: ${{ secrets[format('TG_S3_{0}_{1}', inputs.environment, inputs.layer)] }}
 
 jobs:
   plan:

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -32,7 +32,7 @@ env:
   TERRAGRUNT_EXCLUDE_DIR: "infra/frontend/modules/oidc"
   TERRAGRUNT_NON_INTERACTIVE: true
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  TG_BUCKET_PREFIX: ${{ secrets[format('TG_S3_{0}_{1}', inputs.environment, inputs.layer)] }}
+  TG_BUCKET_PREFIX: ${{ secrets[format('TG_S3_{0}_{1}', inputs.layer, inputs.environment)] }}
 
 jobs:
   plan:

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -1,6 +1,8 @@
 name: Deploy Terragrunt infrastructure
 on:
   pull_request:
+  workflow_dispatch:
+
 
 permissions:
   id-token: write

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -37,21 +37,34 @@ env:
 jobs:
   determine_config:
     runs-on: ubuntu-latest
+    outputs:
+      bucket: {{ steps.echo_bucket.outputs.bucket }}
     steps:
       - id: echo_bucket
         name: Provide the name of the Actions secret that stores the appropriate S3 bucket
-        run: echo 'TG_BUCKET_PREFIX=secrets[format('TG_S3_{0}_{1}', env.ENVIRONMENT, env.LAYER)]' >> $GITHUB_ENV
+        run: echo 'bucket=secrets[format('TG_S3_{0}_{1}', env.ENVIRONMENT, env.LAYER)]' >> "$GITHUB_OUTPUT"
+  authenticate:
+    runs-on: ubuntu-latest
+    outputs:
+      access_key_id: ${{ steps.creds.outputs.aws-access-key-id }}
+      secret_access_key: ${{ steps.creds.outputs.aws-secret-access-key }}
+    steps:
+      - name: Authenticate to AWS
+        id: creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ env.TERRAGRUNT_IAM_ROLE }}
+          output-credentials: true
   plan:
     runs-on: ubuntu-latest
-    needs: [ determine_config ]
+    needs: [ authenticate, determine_config ]
+    env:
+      AWS_ACCESS_KEY_ID: ${{ needs.authenticate.outputs.access_key_id }}
+      AWS_SECRET_ACCESS_KEY: ${{ needs.authenticate.outputs.secret_access_key }}
     steps:
       - name: Checkout
         uses: actions/checkout@main
-      - name: Authenticate to AWS
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.GH_IAM_ROLE_ARN }}
-          aws-region: us-east-1
       - name: Plan
         uses: gruntwork-io/terragrunt-action@v2
         with:
@@ -62,7 +75,10 @@ jobs:
           tg_command: 'run-all plan'
   deploy:
     runs-on: ubuntu-latest
-    needs: [ plan ]
+    needs: [ authenticate, determine_config ]
+    env:
+      AWS_ACCESS_KEY_ID: ${{ needs.authenticate.outputs.access_key_id }}
+      AWS_SECRET_ACCESS_KEY: ${{ needs.authenticate.outputs.secret_access_key }}
     steps:
       - name: Checkout
         uses: actions/checkout@main

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -43,12 +43,12 @@ jobs:
       - id: echo_bucket
         name: Provide the name of the Actions secret that stores the appropriate S3 bucket
         run: echo "bucket=secrets[format('TG_S3_{0}_{1}', env.ENVIRONMENT, env.LAYER)]" >> "$GITHUB_OUTPUT"
-  authenticate:
+  plan:
     runs-on: ubuntu-latest
-    outputs:
-      access_key_id: ${{ steps.creds.outputs.aws-access-key-id }}
-      secret_access_key: ${{ steps.creds.outputs.aws-secret-access-key }}
+    needs: [ determine_config ]
     steps:
+      - name: Checkout
+        uses: actions/checkout@main
       - name: Authenticate to AWS
         id: creds
         uses: aws-actions/configure-aws-credentials@v4
@@ -56,15 +56,6 @@ jobs:
           aws-region: us-east-1
           role-to-assume: ${{ env.TERRAGRUNT_IAM_ROLE }}
           output-credentials: true
-  plan:
-    runs-on: ubuntu-latest
-    needs: [ authenticate, determine_config ]
-    env:
-      AWS_ACCESS_KEY_ID: ${{ needs.authenticate.outputs.access_key_id }}
-      AWS_SECRET_ACCESS_KEY: ${{ needs.authenticate.outputs.secret_access_key }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@main
       - name: Plan
         uses: gruntwork-io/terragrunt-action@v2
         with:
@@ -73,21 +64,22 @@ jobs:
           tg_comment: true
           tg_dir: ${{ env.TG_DIR }}
           tg_command: 'run-all plan'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.access_key_id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.secret_access_key }}
   deploy:
     runs-on: ubuntu-latest
-    needs: [ authenticate, determine_config ]
-    env:
-      AWS_ACCESS_KEY_ID: ${{ needs.authenticate.outputs.access_key_id }}
-      AWS_SECRET_ACCESS_KEY: ${{ needs.authenticate.outputs.secret_access_key }}
+    needs: [ determine_config ]
     steps:
       - name: Checkout
         uses: actions/checkout@main
-
       - name: Authenticate to AWS
+        id: creds
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.GH_IAM_ROLE_ARN }}
           aws-region: us-east-1
+          role-to-assume: ${{ env.TERRAGRUNT_IAM_ROLE }}
+          output-credentials: true
       - name: Deploy
         uses: gruntwork-io/terragrunt-action@v2
         with:
@@ -96,3 +88,6 @@ jobs:
           tg_dir: ${{ env.TG_DIR }}
           tg_comment: true
           tg_command: 'run-all apply'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.access_key_id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.secret_access_key }}

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -23,13 +23,15 @@ permissions:
   id-token: write
 
 env:
-  TG_VERSION: '1.10.5'
+  TG_VERSION: '0.72.5'
+  TF_VERSION: '1.10.5'
   TG_DIR: 'infra'
   ENVIRONMENT: ${{ inputs.environment }}
   LAYER: ${{ inputs.layer }}
   TERRAGRUNT_IAM_ROLE: ${{ secrets.GH_IAM_ROLE_ARN }}
   TERRAGRUNT_EXCLUDE_DIR: "infra/frontend/modules/oidc"
   TERRAGRUNT_NON_INTERACTIVE: true
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   determine_config:
@@ -49,6 +51,8 @@ jobs:
         uses: gruntwork-io/terragrunt-action@v2
         with:
           tg_version: ${{ env.TG_VERSION }}
+          tf_version: ${{ env.TF_VERSION }}
+          tg_comment: true
           tg_dir: ${{ env.TG_DIR }}
           tg_command: 'run-all plan'
   deploy:
@@ -62,5 +66,7 @@ jobs:
         uses: gruntwork-io/terragrunt-action@v2
         with:
           tg_version: ${{ env.TG_VERSION }}
+          tf_version: ${{ env.TF_VERSION }}
           tg_dir: ${{ env.TG_DIR }}
+          tg_comment: true
           tg_command: 'run-all apply'

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -69,7 +69,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.secret_access_key }}
   deploy:
     runs-on: ubuntu-latest
-    needs: [ determine_config ]
+    needs: [ plan ]
     steps:
       - name: Checkout
         uses: actions/checkout@main

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - id: echo_bucket
         name: Provide the name of the Actions secret that stores the appropriate S3 bucket
-        run: echo "bucket=secrets[format('TG_S3_{0}_{1}', env.ENVIRONMENT, env.LAYER)]" >> "$GITHUB_OUTPUT"
+        run: echo "bucket=${{ secrets[format('TG_S3_{0}_{1}', env.ENVIRONMENT, env.LAYER)] }}" >> "$GITHUB_OUTPUT"
   plan:
     runs-on: ubuntu-latest
     needs: [ determine_config ]

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -29,7 +29,6 @@ env:
   TG_DIR: 'infra'
   ENVIRONMENT: ${{ inputs.environment }}
   LAYER: ${{ inputs.layer }}
-  TERRAGRUNT_IAM_ROLE: ${{ secrets.GH_IAM_ROLE_ARN }}
   TERRAGRUNT_EXCLUDE_DIR: "infra/frontend/modules/oidc"
   TERRAGRUNT_NON_INTERACTIVE: true
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -65,8 +65,8 @@ jobs:
           tg_dir: ${{ env.TG_DIR }}
           tg_command: 'run-all plan'
         env:
-          AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.access_key_id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.secret_access_key }}
+          AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
   deploy:
     runs-on: ubuntu-latest
     needs: [ plan ]
@@ -89,5 +89,5 @@ jobs:
           tg_comment: true
           tg_command: 'run-all apply'
         env:
-          AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.access_key_id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.secret_access_key }}
+          AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -41,9 +41,7 @@ jobs:
     steps:
       - id: echo_bucket
         name: Provide the name of the Actions secret that stores the appropriate S3 bucket
-        run: | 
-          echo "${{ format('TG_S3_{0}_{1}', env.ENVIRONMENT, env.LAYER) }}"
-          echo "bucket=${{ secrets[format('TG_S3_{0}_{1}', env.ENVIRONMENT, env.LAYER)] }}" >> "$GITHUB_OUTPUT"
+        run: echo "bucket=${{ secrets[format('TG_S3_{0}_{1}', env.LAYER, env.ENVIRONMENT)] }}" >> "$GITHUB_OUTPUT"
   plan:
     runs-on: ubuntu-latest
     needs: [ determine_config ]

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
-          role-to-assume: ${{ env.TERRAGRUNT_IAM_ROLE }}
+          role-to-assume: ${{ secrets.GH_IAM_ROLE_ARN }}
           output-credentials: true
       - name: Plan
         uses: gruntwork-io/terragrunt-action@v2
@@ -77,7 +77,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
-          role-to-assume: ${{ env.TERRAGRUNT_IAM_ROLE }}
+          role-to-assume:  ${{ secrets.GH_IAM_ROLE_ARN }}
           output-credentials: true
       - name: Deploy
         uses: gruntwork-io/terragrunt-action@v2

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -1,3 +1,4 @@
+name: Deploy Terragrunt infrastructure
 on:
   workflow_dispatch:
     inputs:
@@ -36,9 +37,7 @@ jobs:
     steps:
       - id: echo_bucket
         name: Provide the name of the Actions secret that stores the appropriate S3 bucket
-        run: |
-          bucket="TG_S3_$layer_$environment"
-          echo 'TG_BUCKET_PREFIX=secrets[format('TG_S3_{0}_{1}', env.ENVIRONMENT, env.LAYER)]' >> $GITHUB_ENV
+        run: echo 'TG_BUCKET_PREFIX=secrets[format('TG_S3_{0}_{1}', env.ENVIRONMENT, env.LAYER)]' >> $GITHUB_ENV
   plan:
     runs-on: ubuntu-latest
     needs: [ determine_config ]

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -32,19 +32,11 @@ env:
   TERRAGRUNT_EXCLUDE_DIR: "infra/frontend/modules/oidc"
   TERRAGRUNT_NON_INTERACTIVE: true
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  TG_BUCKET_PREFIX: ${{ secrets[format('TG_S3_{0}_{1}', env.LAYER, env.ENVIRONMENT)] }}
 
 jobs:
-  determine_config:
-    runs-on: ubuntu-latest
-    outputs:
-      bucket: ${{ steps.echo_bucket.outputs.bucket }}
-    steps:
-      - id: echo_bucket
-        name: Provide the name of the Actions secret that stores the appropriate S3 bucket
-        run: echo "bucket=${{ secrets[format('TG_S3_{0}_{1}', env.LAYER, env.ENVIRONMENT)] }}" >> "$GITHUB_OUTPUT"
   plan:
     runs-on: ubuntu-latest
-    needs: [ determine_config ]
     steps:
       - name: Checkout
         uses: actions/checkout@main

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -26,7 +26,6 @@ permissions:
 env:
   TG_VERSION: '0.72.5'
   TF_VERSION: '1.10.5'
-  TG_DIR: 'infra'
   ENVIRONMENT: ${{ inputs.environment }}
   LAYER: ${{ inputs.layer }}
   TERRAGRUNT_EXCLUDE_DIR: "infra/frontend/modules/oidc"
@@ -53,7 +52,6 @@ jobs:
           tg_version: ${{ env.TG_VERSION }}
           tf_version: ${{ env.TF_VERSION }}
           tg_comment: true
-          tg_dir: ${{ env.TG_DIR }}
           tg_command: 'run-all plan'
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
@@ -76,7 +74,6 @@ jobs:
         with:
           tg_version: ${{ env.TG_VERSION }}
           tf_version: ${{ env.TF_VERSION }}
-          tg_dir: ${{ env.TG_DIR }}
           tg_comment: true
           tg_command: 'run-all apply'
         env:

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -1,23 +1,6 @@
 name: Deploy Terragrunt infrastructure
 on:
-  workflow_dispatch:
-    inputs:
-      environment:
-        description: The environment (stage or prod).
-        required: true
-        default: "stage"
-        type: choice
-        options:
-          - STAGE
-          - PROD
-      layer:
-        description: The layer of the stack (backend or frontend).
-        required: true
-        default: "frontend"
-        type: choice
-        options:
-          - FRONTEND
-          - BACKEND
+  pull_request:
 
 permissions:
   id-token: write
@@ -26,16 +9,14 @@ permissions:
 env:
   TG_VERSION: '0.72.5'
   TF_VERSION: '1.10.5'
-  ENVIRONMENT: ${{ inputs.environment }}
-  LAYER: ${{ inputs.layer }}
   TERRAGRUNT_EXCLUDE_DIR: "**/*/oidc"
   TERRAGRUNT_NON_INTERACTIVE: true
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  TG_BUCKET_PREFIX: ${{ secrets[format('TG_S3_{0}_{1}', inputs.layer, inputs.environment)] }}
 
 jobs:
   plan:
     runs-on: ubuntu-latest
+    environment: frontend-stage
     steps:
       - name: Checkout
         uses: actions/checkout@main
@@ -57,8 +38,10 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
+          TG_BUCKET_PREFIX: ${{ secrets.TG_BUCKET_PREFIX }}
   deploy:
     runs-on: ubuntu-latest
+    environment: frontend-stage
     needs: [ plan ]
     steps:
       - name: Checkout
@@ -80,3 +63,4 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
+          TG_BUCKET_PREFIX: ${{ secrets.TG_BUCKET_PREFIX }}

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -38,11 +38,11 @@ jobs:
   determine_config:
     runs-on: ubuntu-latest
     outputs:
-      bucket: {{ steps.echo_bucket.outputs.bucket }}
+      bucket: ${{ steps.echo_bucket.outputs.bucket }}
     steps:
       - id: echo_bucket
         name: Provide the name of the Actions secret that stores the appropriate S3 bucket
-        run: echo 'bucket=secrets[format('TG_S3_{0}_{1}', env.ENVIRONMENT, env.LAYER)]' >> "$GITHUB_OUTPUT"
+        run: echo "bucket=secrets[format('TG_S3_{0}_{1}', env.ENVIRONMENT, env.LAYER)]" >> "$GITHUB_OUTPUT"
   authenticate:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   id-token: write
+  contents: read
 
 env:
   TG_VERSION: '0.72.5'
@@ -46,7 +47,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
-
+      - name: Authenticate to AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.GH_IAM_ROLE_ARN }}
+          aws-region: us-east-1
       - name: Plan
         uses: gruntwork-io/terragrunt-action@v2
         with:
@@ -62,6 +67,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@main
 
+      - name: Authenticate to AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.GH_IAM_ROLE_ARN }}
+          aws-region: us-east-1
       - name: Deploy
         uses: gruntwork-io/terragrunt-action@v2
         with:


### PR DESCRIPTION
This PR integrates Terragrunt into the CI/CD processes. As a rough start, it runs terragrunt plan and apply on all directories (except OIDC module directory which does not need to be re-run). This PR also establishes AWS authentication for CI/CD using the `configure-aws-credentials` action.