### PR TITLE
Fix environment in frontend stage environment

### DIFF
--- a/infra/frontend/live/stage/env.hcl
+++ b/infra/frontend/live/stage/env.hcl
@@ -1,3 +1,3 @@
 locals {
-  environment="live"
+  environment="stage"
 }


### PR DESCRIPTION
Quick fix -- environment name is accidentally set to 'live' in `frontend/live/stage/env.hcl`. This causes state buckets to be misnamed.