### PR TITLE
Fix invalid workflows

### DIFF
--- a/.github/workflows/deployment-trigger.yaml
+++ b/.github/workflows/deployment-trigger.yaml
@@ -62,9 +62,9 @@ jobs:
             infra/backend/live/stage/**/**
             infra/backend/live/prod/**/**
   trigger-deploy-fe-stage:
-    needs: [ detect_changed ]
+    needs: [ detect-changed ]
     name: Trigger frontend-stage-deploy if needed
-    if: needs.jobs.detect_changed.outputs.fe-stage-changes == true || needs.jobs.detect_changed.outputs.fe-common-changes == true
+    if: needs.jobs.detect-changed.outputs.fe-stage-changes == true || needs.jobs.detect-changed.outputs.fe-common-changes == true
     uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
     with:
       actions_environment: "frontend-stage"
@@ -72,9 +72,9 @@ jobs:
       # deploy: true
     secrets: inherit
   trigger-deploy-fe-prod:
-    needs: [ detect_changed ]
+    needs: [ detect-changed ]
     name: Trigger frontend-stage-deploy if needed
-    if: needs.jobs.detect_changed.outputs.fe-prod-changes == true || needs.jobs.detect_changed.outputs.fe-common-changes == true
+    if: needs.jobs.detect-changed.outputs.fe-prod-changes == true || needs.jobs.detect-changed.outputs.fe-common-changes == true
     uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
     with:
       actions_environment: "frontend-prod"
@@ -82,9 +82,9 @@ jobs:
       # deploy: true
     secrets: inherit
   trigger-deploy-be-stage:
-    needs: [ detect_changed ]
+    needs: [ detect-changed ]
     name: Trigger backend-stage-deploy if needed
-    if: needs.jobs.detect_changed.outputs.be-stage-changes == true || needs.jobs.detect_changed.outputs.be-common-changes == true
+    if: needs.jobs.detect-changed.outputs.be-stage-changes == true || needs.jobs.detect-changed.outputs.be-common-changes == true
     uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
     with:
       actions_environment: "backend-stage"
@@ -92,9 +92,9 @@ jobs:
       # deploy: true
     secrets: inherit
   trigger-deploy-be-prod:
-    needs: [ detect_changed ]
+    needs: [ detect-changed ]
     name: Trigger backend-stage-deploy if needed
-    if: needs.jobs.detect_changed.outputs.be-prod-changes == true || needs.jobs.detect_changed.outputs.be-common-changes == true
+    if: needs.jobs.detect-changed.outputs.be-prod-changes == true || needs.jobs.detect-changed.outputs.be-common-changes == true
     uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
     with:
       actions_environment: "backend-prod"

--- a/.github/workflows/deployment-trigger.yaml
+++ b/.github/workflows/deployment-trigger.yaml
@@ -64,7 +64,7 @@ jobs:
   trigger-deploy-fe-stage:
     needs: [ detect_changed ]
     name: Trigger frontend-stage-deploy if needed
-    if: needs.jobs.detect_changed.outputs.fe-stage-changes == "true" || needs.jobs.detect_changed.outputs.fe-common-changes == "true"
+    if: needs.jobs.detect_changed.outputs.fe-stage-changes == true || needs.jobs.detect_changed.outputs.fe-common-changes == true
     uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
     with:
       actions_environment: "frontend-stage"
@@ -74,7 +74,7 @@ jobs:
   trigger-deploy-fe-prod:
     needs: [ detect_changed ]
     name: Trigger frontend-stage-deploy if needed
-    if: needs.jobs.detect_changed.outputs.fe-prod-changes == "true" || needs.jobs.detect_changed.outputs.fe-common-changes == "true"
+    if: needs.jobs.detect_changed.outputs.fe-prod-changes == true || needs.jobs.detect_changed.outputs.fe-common-changes == true
     uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
     with:
       actions_environment: "frontend-prod"
@@ -84,7 +84,7 @@ jobs:
   trigger-deploy-be-stage:
     needs: [ detect_changed ]
     name: Trigger backend-stage-deploy if needed
-    if: needs.jobs.detect_changed.outputs.be-stage-changes == "true" || needs.jobs.detect_changed.outputs.be-common-changes == "true"
+    if: needs.jobs.detect_changed.outputs.be-stage-changes == true || needs.jobs.detect_changed.outputs.be-common-changes == true
     uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
     with:
       actions_environment: "backend-stage"
@@ -94,7 +94,7 @@ jobs:
   trigger-deploy-be-prod:
     needs: [ detect_changed ]
     name: Trigger backend-stage-deploy if needed
-    if: needs.jobs.detect_changed.outputs.be-prod-changes == "true" || needs.jobs.detect_changed.outputs.be-common-changes == "true"
+    if: needs.jobs.detect_changed.outputs.be-prod-changes == true || needs.jobs.detect_changed.outputs.be-common-changes == true
     uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
     with:
       actions_environment: "backend-prod"

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -14,7 +14,7 @@ on:
         description: 'Any Terragrunt directories to exclude, passed from the caller workflow. If a relative path is specified, it should be relative from the working directory.'
         required: false
         type: string
-        default: ""
+        default: ''
       deploy:
         description: 'Whether to deploy the infrastructure or not, passed from the caller workflow'
         required: false
@@ -29,7 +29,7 @@ env:
   TG_VERSION: '0.72.5'
   TF_VERSION: '1.10.5'
   ACTIONS_ENVIRONMENT: ${{ inputs.actions_environment }}
-  TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.tg_exclude_dir != "" && format("**/*/oidc, {0}", inputs.tg_exclude_dir) || "**/*/oidc" }} # excluded because it only needs to run once (to set up OIDC provider for Actions to authenticate to AWS)
+  TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.tg_exclude_dir != '' && format('**/*/oidc, {0}', inputs.tg_exclude_dir) || '**/*/oidc' }} # excluded because it only needs to run once (to set up OIDC provider for Actions to authenticate to AWS)
   TERRAGRUNT_WORKING_DIR: ${{ inputs.tg_working_dir }}
   TERRAGRUNT_NON_INTERACTIVE: true
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -38,7 +38,7 @@ env:
 jobs:
   plan:
     runs-on: ubuntu-latest
-    environment: ${{ env.ACTIONS_ENVIRONMENT }}
+    environment: ${{ github.env.ACTIONS_ENVIRONMENT }}
     steps:
       - name: Checkout
         uses: actions/checkout@main
@@ -64,7 +64,7 @@ jobs:
   deploy:
     if: env.WILL_DEPLOY == 'true'
     runs-on: ubuntu-latest
-    environment: ${{ env.ACTIONS_ENVIRONMENT }}
+    environment: ${{ github.env.ACTIONS_ENVIRONMENT }}
     needs: [ plan ]
     steps:
       - name: Checkout


### PR DESCRIPTION
Quick fixes --
- removes quote around `true` to avoid syntax error.
- fixes misspelled job name `detect_changed` -> `detect-changed`
- changes double quotes to single quotes where needed
- uses `github` context instead of `env` context when setting environment, as the `env` context is not provided to `jobs.<job-id>.environment`.