### PR TITLE
Fix minor syntax error

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -62,7 +62,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
           TG_BUCKET_PREFIX: ${{ secrets.TG_BUCKET_PREFIX }}
   deploy:
-    if: github.env.WILL_DEPLOY == 'true'
+    if: github.env.WILL_DEPLOY == true
     runs-on: ubuntu-latest
     environment: ${{ github.env.ACTIONS_ENVIRONMENT }}
     needs: [ plan ]

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -62,7 +62,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
           TG_BUCKET_PREFIX: ${{ secrets.TG_BUCKET_PREFIX }}
   deploy:
-    if: env.WILL_DEPLOY == 'true'
+    if: github.env.WILL_DEPLOY == 'true'
     runs-on: ubuntu-latest
     environment: ${{ github.env.ACTIONS_ENVIRONMENT }}
     needs: [ plan ]


### PR DESCRIPTION
Another quick fix -- `env` context is still erroneously being used where it is not provided. `github` context is used to fix this instead. Also this PR cleans up unnecessary single quotes around `true`.