### PR TITLE
Fix failing deployments

### DIFF
--- a/.github/workflows/deployment-trigger.yaml
+++ b/.github/workflows/deployment-trigger.yaml
@@ -68,7 +68,7 @@ jobs:
     uses: nestrr/flock-infra/.github/workflows/deployment.yaml@deployment-fix
     with:
       actions_environment: "frontend-stage"
-      tg_working_dir: "./infra/frontend/live/stage"
+      tg_working_dir: "infra/frontend/live/stage"
       # deploy: true
     secrets: inherit
   trigger-deploy-fe-prod:
@@ -78,7 +78,7 @@ jobs:
     uses: nestrr/flock-infra/.github/workflows/deployment.yaml@deployment-fix
     with:
       actions_environment: "frontend-prod"
-      tg_working_dir: "infra/frontend/live/prod"
+      tg_include_dir: "infra/frontend/live/prod"
       # deploy: true
     secrets: inherit
   trigger-deploy-be-stage:
@@ -88,7 +88,7 @@ jobs:
     uses: nestrr/flock-infra/.github/workflows/deployment.yaml@deployment-fix
     with:
       actions_environment: "backend-stage"
-      tg_working_dir: "infra/backend/live/stage"
+      tg_include_dir: "infra/backend/live/stage"
       # deploy: true
     secrets: inherit
   trigger-deploy-be-prod:
@@ -98,6 +98,6 @@ jobs:
     uses: nestrr/flock-infra/.github/workflows/deployment.yaml@deployment-fix
     with:
       actions_environment: "backend-prod"
-      tg_working_dir: "infra/backend/live/prod"
+      tg_include_dir: "infra/backend/live/prod"
       # deploy: true
     secrets: inherit

--- a/.github/workflows/deployment-trigger.yaml
+++ b/.github/workflows/deployment-trigger.yaml
@@ -68,7 +68,7 @@ jobs:
     uses: nestrr/flock-infra/.github/workflows/deployment.yaml@deployment-fix
     with:
       actions_environment: "frontend-stage"
-      tg_working_dir: "infra/frontend/live/stage"
+      tg_include_dir: "infra/frontend/live/stage"
       # deploy: true
     secrets: inherit
   trigger-deploy-fe-prod:

--- a/.github/workflows/deployment-trigger.yaml
+++ b/.github/workflows/deployment-trigger.yaml
@@ -68,7 +68,7 @@ jobs:
     uses: nestrr/flock-infra/.github/workflows/deployment.yaml@deployment-fix
     with:
       actions_environment: "frontend-stage"
-      tg_working_dir: "./infra/frontend/live/stage/oidc"
+      tg_working_dir: "./infra/frontend/live/stage"
       # deploy: true
     secrets: inherit
   trigger-deploy-fe-prod:

--- a/.github/workflows/deployment-trigger.yaml
+++ b/.github/workflows/deployment-trigger.yaml
@@ -68,7 +68,7 @@ jobs:
     uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
     with:
       actions_environment: "frontend-stage"
-      tg_working_dir: "infra/frontend/live/stage"
+      tg_working_dir: "infra/frontend/live/stage/oidc"
       # deploy: true
     secrets: inherit
   trigger-deploy-fe-prod:

--- a/.github/workflows/deployment-trigger.yaml
+++ b/.github/workflows/deployment-trigger.yaml
@@ -68,7 +68,7 @@ jobs:
     uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
     with:
       actions_environment: "frontend-stage"
-      tg_working_dir: "infra/frontend/live/stage/oidc"
+      tg_working_dir: "./infra/frontend/live/stage/oidc"
       # deploy: true
     secrets: inherit
   trigger-deploy-fe-prod:

--- a/.github/workflows/deployment-trigger.yaml
+++ b/.github/workflows/deployment-trigger.yaml
@@ -65,7 +65,7 @@ jobs:
     needs: detect-changed
     name: Trigger frontend-stage-deploy if needed
     if: needs.detect-changed.outputs.fe-stage-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true'
-    uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
+    uses: nestrr/flock-infra/.github/workflows/deployment.yaml@deployment-fix
     with:
       actions_environment: "frontend-stage"
       tg_working_dir: "./infra/frontend/live/stage/oidc"
@@ -75,7 +75,7 @@ jobs:
     needs: detect-changed
     name: Trigger frontend-stage-deploy if needed
     if: needs.detect-changed.outputs.fe-prod-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true'
-    uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
+    uses: nestrr/flock-infra/.github/workflows/deployment.yaml@deployment-fix
     with:
       actions_environment: "frontend-prod"
       tg_working_dir: "infra/frontend/live/prod"
@@ -85,7 +85,7 @@ jobs:
     needs: detect-changed
     name: Trigger backend-stage-deploy if needed
     if: needs.detect-changed.outputs.be-stage-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true'
-    uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
+    uses: nestrr/flock-infra/.github/workflows/deployment.yaml@deployment-fix
     with:
       actions_environment: "backend-stage"
       tg_working_dir: "infra/backend/live/stage"
@@ -95,7 +95,7 @@ jobs:
     needs: detect-changed
     name: Trigger backend-stage-deploy if needed
     if: needs.detect-changed.outputs.be-prod-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true'
-    uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
+    uses: nestrr/flock-infra/.github/workflows/deployment.yaml@deployment-fix
     with:
       actions_environment: "backend-prod"
       tg_working_dir: "infra/backend/live/prod"

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -30,7 +30,7 @@ env:
   TF_VERSION: '1.10.5'
   ACTIONS_ENVIRONMENT: ${{ inputs.actions_environment }}
   TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.tg_exclude_dir != '' && format('**/*/oidc, {0}', inputs.tg_exclude_dir) || '**/*/oidc' }} # excluded because it only needs to run once (to set up OIDC provider for Actions to authenticate to AWS)
-  TERRAGRUNT_WORKING_DIR: ${{ inputs.tg_working_dir }}
+  TERRAGRUNT_INCLUDE_DIR: ${{ inputs.tg_working_dir }}
   TERRAGRUNT_NON_INTERACTIVE: true
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   WILL_DEPLOY: ${{ inputs.deploy }}
@@ -55,7 +55,6 @@ jobs:
           tg_version: ${{ env.TG_VERSION }}
           tf_version: ${{ env.TF_VERSION }}
           tg_comment: true
-          tg_dir: ${{ env.TERRAGRUNT_WORKING_DIR }}
           tg_command: 'run-all plan'
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
@@ -82,7 +81,6 @@ jobs:
           tg_version: ${{ env.TG_VERSION }}
           tf_version: ${{ env.TF_VERSION }}
           tg_comment: true
-          tg_dir: ${{ env.TERRAGRUNT_WORKING_DIR }}
           tg_command: 'run-all apply'
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -55,6 +55,7 @@ jobs:
           tg_version: ${{ env.TG_VERSION }}
           tf_version: ${{ env.TF_VERSION }}
           tg_comment: true
+          tg_dir: "."
           tg_command: 'run-all plan'
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -6,8 +6,8 @@ on:
         description: 'The environment in GitHub Actions, passed from the caller workflow'
         required: true
         type: string
-      tg_working_dir:
-        description: 'The Terragrunt working directory, passed from the caller workflow'
+      tg_include_dir:
+        description: 'The Terragrunt directories to include, passed from the caller workflow'
         required: true
         type: string
       tg_exclude_dir:
@@ -30,7 +30,7 @@ env:
   TF_VERSION: '1.10.5'
   ACTIONS_ENVIRONMENT: ${{ inputs.actions_environment }}
   TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.tg_exclude_dir != '' && format('**/*/oidc, {0}', inputs.tg_exclude_dir) || '**/*/oidc' }} # excluded because it only needs to run once (to set up OIDC provider for Actions to authenticate to AWS)
-  TERRAGRUNT_INCLUDE_DIR: ${{ inputs.tg_working_dir }}
+  TERRAGRUNT_INCLUDE_DIR: ${{ inputs.tg_include_dir }}
   TERRAGRUNT_NON_INTERACTIVE: true
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   WILL_DEPLOY: ${{ inputs.deploy }}
@@ -55,7 +55,6 @@ jobs:
           tg_version: ${{ env.TG_VERSION }}
           tf_version: ${{ env.TF_VERSION }}
           tg_comment: true
-          tg_dir: "."
           tg_command: 'run-all plan'
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}

--- a/infra/frontend/live/stage/env.hcl
+++ b/infra/frontend/live/stage/env.hcl
@@ -1,4 +1,3 @@
 locals {
   environment="live"
-  test_change="2"
 }

--- a/infra/frontend/live/stage/env.hcl
+++ b/infra/frontend/live/stage/env.hcl
@@ -1,4 +1,4 @@
 locals {
   environment="live"
-  test_change="1"
+  test_change="2"
 }

--- a/infra/frontend/live/stage/oidc/terragrunt.hcl
+++ b/infra/frontend/live/stage/oidc/terragrunt.hcl
@@ -21,7 +21,7 @@ include "common" {
 # Configure the version of the module to use in this environment. This allows you to promote new versions one
 # environment at a time (e.g., qa -> stage -> prod).
 terraform {
-  source = "${include.common.locals.base_source_url}?ref=v0.1.0-beta.4"
+  source = "${include.common.locals.base_source_url}?ref=v0.1.0-beta.3"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Terragrunt automated deployments fail due to an lstat error. This is because the working directory is set, which confuses Terragrunt as it tries to search for other important units like the root unit.

So, this PR allows the deployment-trigger workflow to set the Terragrunt included directories instead of the working directory. The net effect is the same.