### PR TITLE
Create module to generate Doppler service token

### DIFF
--- a/infra/frontend/modules/service_token/main.tf
+++ b/infra/frontend/modules/service_token/main.tf
@@ -1,0 +1,91 @@
+data "aws_caller_identity" "self" {}
+
+resource "doppler_service_token" "ci_service_token" {
+  project = var.project
+  config  = var.config
+  name    = format("Service_Token_%s_%s_%s---%s", var.project, var.config, timestamp(), uuid())
+  access  = "read"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_kms_key" "cmk" {
+  enable_key_rotation     = true
+  deletion_window_in_days = 20
+}
+
+resource "aws_kms_key_policy" "cmk_admin_policy" {
+  key_id = aws_kms_key.cmk.id
+  policy = jsonencode({
+    Id = "EnableEphemeralUserToManageCMKKey"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Resource = [aws_kms_key.cmk.arn]
+        Action = ["kms:Create*",
+          "kms:Describe*",
+          "kms:Enable*",
+          "kms:List*",
+          "kms:Put*",
+          "kms:Get*",
+          "kms:Decrypt*",
+        "kms:Encrypt*"]
+        Principal = {
+          type        = "AWS"
+          identifiers = [data.aws_caller_identity.self.arn]
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_secretsmanager_secret" "doppler_service_token_secret" {
+  #  count=provider::assert::expired(timeadd(existing_doppler_token.tags.created.not_after, "336h"))
+  # resulting name will resemble "DOPPLER-TOKEN_flock-frontend_dev"
+  name        = format("DOPPLER-ST_%s_%s", var.project, var.config)
+  description = "Doppler Service Token"
+  kms_key_id  = aws_kms_key.cmk.key_id
+  tags = {
+    "created" : timestamp()
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_kms_ciphertext" "doppler_service_token_ciphertext" {
+  key_id    = aws_kms_key.cmk.key_id
+  plaintext = doppler_service_token.ci_service_token.key
+}
+
+data "aws_iam_policy_document" "secret_management_policy" {
+  statement {
+    sid    = "EnableEphemeralUserToManageSecrets"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_caller_identity.self.arn]
+    }
+    actions = [
+      "secretsmanager:Create*",
+      "secretsmanager:Get*",
+      "secretsmanager:List*",
+      "secretsmanager:Update*",
+      "secretsmanager:Put*",
+      "secretsmanager:Tag*",
+      "secretsmanager:Untag*",
+      "secretsmanager:Delete*",
+    ]
+    resources = [
+      aws_secretsmanager_secret.doppler_service_token_secret.arn,
+      aws_secretsmanager_secret_version.doppler_personal_token_secret_val.arn
+    ]
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "doppler_personal_token_secret_val" {
+  secret_id     = aws_secretsmanager_secret.doppler_service_token_secret.id
+  secret_string = aws_kms_ciphertext.doppler_service_token_ciphertext.ciphertext_blob
+}

--- a/infra/frontend/modules/service_token/outputs.tf
+++ b/infra/frontend/modules/service_token/outputs.tf
@@ -1,0 +1,6 @@
+output "doppler_service_token_secret_id" {
+  value       = aws_secretsmanager_secret.doppler_service_token_secret.id
+  description = "The id of the AWSSM secret ID that holds the service token value"
+  sensitive   = true
+}
+

--- a/infra/frontend/modules/service_token/providers.tf
+++ b/infra/frontend/modules/service_token/providers.tf
@@ -1,0 +1,3 @@
+provider "doppler" {
+  doppler_token = vars.doppler_personal_token
+}

--- a/infra/frontend/modules/service_token/variables.tf
+++ b/infra/frontend/modules/service_token/variables.tf
@@ -1,0 +1,18 @@
+variable "doppler_personal_token" {
+  description = "This is your Doppler personal token."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+variable "doppler_service_token_secret_name" {
+  description = "This is the name of the Doppler service token secret in AWS SM"
+  type = string
+}
+variable "project" {
+  description = "This is the project name in Doppler."
+  type        = string
+}
+variable "config" {
+  description = "This is the config name within the Doppler project."
+  type        = string
+}


### PR DESCRIPTION
A Doppler service token will be necessary to access secrets. This PR creates a Terraform module that creates that service token and stores it in AWS SM, given a Doppler personal token.