### PR TITLE
Remove manual provider setup from service token module

### DIFF
--- a/infra/frontend/modules/service_token/providers.tf
+++ b/infra/frontend/modules/service_token/providers.tf
@@ -1,3 +1,0 @@
-provider "doppler" {
-  doppler_token = vars.doppler_personal_token
-}


### PR DESCRIPTION
As title indicates, this PR removes manual provider setup from the service_token module. As a result, Terragrunt configs will be responsible for setting up providers, not the modules.