### PR TITLE
Fix failing deployments

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -68,7 +68,7 @@ jobs:
           tg_version: ${{ env.TG_VERSION }}
           tf_version: ${{ env.TF_VERSION }}
           tg_comment: true
-          tg_command: format('run-all {0} plan', env.PLAN_FLAGS)
+          tg_command: ${{ format('run-all {0} plan', env.PLAN_FLAGS) }}
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
@@ -94,7 +94,7 @@ jobs:
           tg_version: ${{ env.TG_VERSION }}
           tf_version: ${{ env.TF_VERSION }}
           tg_comment: true
-          tg_command: format('run-all {0} apply', env.APPLY_FLAGS)
+          tg_command: ${{ format('run-all {0} apply', env.APPLY_FLAGS) }}
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}


### PR DESCRIPTION
Terragrunt deployments are currently failing again after #17 because the `tg_command` argument's values are passed as plaintext to the Terragrunt command. Accordingly, this PR adds curly brackets around the value to ensure that it is parsed by GitHub Actions.