### PR TITLE
Split Terragrunt deploy and plan steps into two workflows

### DIFF
--- a/.github/workflows/deploy-trigger.yaml
+++ b/.github/workflows/deploy-trigger.yaml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - closed
 
 permissions:
   id-token: write
@@ -11,6 +13,7 @@ permissions:
 
 jobs:
   detect-changed:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       fe-stage-changes: ${{ steps.changed-files-fe-stage.outputs.any_changed }}
@@ -65,39 +68,35 @@ jobs:
     needs: detect-changed
     name: Trigger frontend-stage-deploy if needed
     if: needs.detect-changed.outputs.fe-stage-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true'
-    uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
+    uses: nestrr/flock-infra/.github/workflows/deploy.yaml@main
     with:
       actions_environment: "frontend-stage"
       tg_include_dir: "infra/frontend/live/stage"
-      # deploy: true
     secrets: inherit
   trigger-deploy-fe-prod:
     needs: detect-changed
     name: Trigger frontend-stage-deploy if needed
     if: needs.detect-changed.outputs.fe-prod-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true'
-    uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
+    uses: nestrr/flock-infra/.github/workflows/deploy.yaml@main
     with:
       actions_environment: "frontend-prod"
       tg_include_dir: "infra/frontend/live/prod"
-      # deploy: true
     secrets: inherit
   trigger-deploy-be-stage:
     needs: detect-changed
     name: Trigger backend-stage-deploy if needed
     if: needs.detect-changed.outputs.be-stage-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true'
-    uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
+    uses: nestrr/flock-infra/.github/workflows/deploy.yaml@main
     with:
       actions_environment: "backend-stage"
       tg_include_dir: "infra/backend/live/stage"
-      # deploy: true
     secrets: inherit
   trigger-deploy-be-prod:
     needs: detect-changed
     name: Trigger backend-stage-deploy if needed
     if: needs.detect-changed.outputs.be-prod-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true'
-    uses: nestrr/flock-infra/.github/workflows/deployment.yaml@main
+    uses: nestrr/flock-infra/.github/workflows/deploy.yaml@main
     with:
       actions_environment: "backend-prod"
       tg_include_dir: "infra/backend/live/prod"
-      # deploy: true
     secrets: inherit

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,68 @@
+name: Deploy Terragrunt infrastructure
+on:
+  workflow_call:
+    inputs:
+      actions_environment:
+        description: 'The environment in GitHub Actions, passed from the caller workflow'
+        required: true
+        type: string
+      tg_include_dir:
+        description: 'The Terragrunt directories to include, passed from the caller workflow'
+        required: true
+        type: string
+      tg_exclude_dir:
+        description: 'Any Terragrunt directories to exclude, passed from the caller workflow. If a relative path is specified, it should be relative from the working directory.'
+        required: false
+        type: string
+        default: ''
+      deploy:
+        description: 'Whether to deploy the infrastructure or not, passed from the caller workflow'
+        required: false
+        type: boolean
+        default: false
+      apply_flags:
+        description: 'Additional flags to pass Terragrunt apply'
+        required: false
+        type: string
+        default: ''
+
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  TG_VERSION: '0.72.5'
+  TF_VERSION: '1.10.5'
+  ACTIONS_ENVIRONMENT: ${{ inputs.actions_environment }}
+  TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.tg_exclude_dir != '' && format('**/*/oidc, {0}', inputs.tg_exclude_dir) || '**/*/oidc' }} # excluded because it only needs to run once (to set up OIDC provider for Actions to authenticate to AWS)
+  TERRAGRUNT_INCLUDE_DIR: ${{ inputs.tg_include_dir }}
+  TERRAGRUNT_NON_INTERACTIVE: true
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  APPLY_FLAGS: ${{ inputs.apply_flags }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ github.env.ACTIONS_ENVIRONMENT }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - name: Authenticate to AWS
+        id: creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-to-assume:  ${{ secrets.GH_IAM_ROLE_ARN }}
+          output-credentials: true
+      - name: Deploy
+        uses: gruntwork-io/terragrunt-action@v2
+        with:
+          tg_version: ${{ env.TG_VERSION }}
+          tf_version: ${{ env.TF_VERSION }}
+          tg_comment: true
+          tg_command: format('run-all {0} apply', env.APPLY_FLAGS)
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
+          TG_BUCKET_PREFIX: ${{ secrets.TG_BUCKET_PREFIX }}

--- a/.github/workflows/plan-trigger.yaml
+++ b/.github/workflows/plan-trigger.yaml
@@ -1,0 +1,107 @@
+name: Trigger Terragrunt infrastructure planning
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  detect-changed:
+    runs-on: ubuntu-latest
+    outputs:
+      fe-stage-changes: ${{ steps.changed-files-fe-stage.outputs.any_changed }}
+      fe-prod-changes: ${{ steps.changed-files-fe-prod.outputs.any_changed }}
+      fe-common-changes: ${{ steps.changed-files-fe-common.outputs.any_changed }}
+      be-stage-changes: ${{ steps.changed-files-be-stage.outputs.any_changed }}
+      be-prod-changes: ${{ steps.changed-files-be-prod.outputs.any_changed }}
+      be-common-changes: ${{ steps.changed-files-be-common.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      # Not including modules directories here, because Terragrunt units lock down the module version used
+      # So if a module changes, it will only affect infrastructure if one of the units are changed - which would be caught here
+      - name: Get changed files from frontend-stage
+        id: changed-files-fe-stage
+        uses: tj-actions/changed-files@v45
+        with:
+          files: 'infra/frontend/live/stage/**'
+      - name: Get changed files from frontend-prod
+        id: changed-files-fe-prod
+        uses: tj-actions/changed-files@v45
+        with:
+          files: 'infra/frontend/live/prod/**'
+      - name: Get changed files common to the frontend
+        id: changed-files-fe-common
+        uses: tj-actions/changed-files@v45
+        with:
+          files: 'infra/frontend/live/**'
+          files_ignore: |
+            infra/frontend/live/stage/**/**
+            infra/frontend/live/prod/**/**
+      - name: Get changed files from backend-stage
+        id: changed-files-be-stage
+        uses: tj-actions/changed-files@v45
+        with:
+          files: 'infra/backend/live/stage/**/**'
+      - name: Get changed files from backend-prod
+        id: changed-files-be-prod
+        uses: tj-actions/changed-files@v45
+        with:
+          files: 'infra/backend/live/prod/**/**'
+      - name: Get changed files common to the backend
+        id: changed-files-be-common
+        uses: tj-actions/changed-files@v45
+        with:
+          files: 'infra/backend/live/**/**'
+          files_ignore: |
+            infra/backend/live/stage/**/**
+            infra/backend/live/prod/**/**
+  trigger-deploy-fe-stage:
+    needs: detect-changed
+    name: Trigger frontend-stage-deploy if needed
+    if: needs.detect-changed.outputs.fe-stage-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true'
+    uses: nestrr/flock-infra/.github/workflows/plan.yaml@main
+    with:
+      actions_environment: "frontend-stage"
+      tg_include_dir: "infra/frontend/live/stage"
+      # deploy: true
+    secrets: inherit
+  trigger-deploy-fe-prod:
+    needs: detect-changed
+    name: Trigger frontend-stage-deploy if needed
+    if: needs.detect-changed.outputs.fe-prod-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true'
+    uses: nestrr/flock-infra/.github/workflows/plan.yaml@main
+    with:
+      actions_environment: "frontend-prod"
+      tg_include_dir: "infra/frontend/live/prod"
+      # deploy: true
+    secrets: inherit
+  trigger-deploy-be-stage:
+    needs: detect-changed
+    name: Trigger backend-stage-deploy if needed
+    if: needs.detect-changed.outputs.be-stage-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true'
+    uses: nestrr/flock-infra/.github/workflows/plan.yaml@main
+    with:
+      actions_environment: "backend-stage"
+      tg_include_dir: "infra/backend/live/stage"
+      # deploy: true
+    secrets: inherit
+  trigger-deploy-be-prod:
+    needs: detect-changed
+    name: Trigger backend-stage-deploy if needed
+    if: needs.detect-changed.outputs.be-prod-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true'
+    uses: nestrr/flock-infra/.github/workflows/plan.yaml@main
+    with:
+      actions_environment: "backend-prod"
+      tg_include_dir: "infra/backend/live/prod"
+      # deploy: true
+    secrets: inherit

--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -1,4 +1,4 @@
-name: Deploy Terragrunt infrastructure
+name: Plan Terragrunt infrastructure
 on:
   workflow_call:
     inputs:
@@ -15,18 +15,8 @@ on:
         required: false
         type: string
         default: ''
-      deploy:
-        description: 'Whether to deploy the infrastructure or not, passed from the caller workflow'
-        required: false
-        type: boolean
-        default: false
       plan_flags:
         description: 'Additional flags to pass Terragrunt plan'
-        required: false
-        type: string
-        default: ''
-      apply_flags:
-        description: 'Additional flags to pass Terragrunt apply'
         required: false
         type: string
         default: ''
@@ -44,9 +34,7 @@ env:
   TERRAGRUNT_INCLUDE_DIR: ${{ inputs.tg_include_dir }}
   TERRAGRUNT_NON_INTERACTIVE: true
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  WILL_DEPLOY: ${{ inputs.deploy }}
   PLAN_FLAGS: ${{ inputs.plan_flags }}
-  APPLY_FLAGS: ${{ inputs.apply_flags }}
 
 jobs:
   plan:
@@ -68,33 +56,7 @@ jobs:
           tg_version: ${{ env.TG_VERSION }}
           tf_version: ${{ env.TF_VERSION }}
           tg_comment: true
-          tg_command: ${{ format('run-all {0} plan', env.PLAN_FLAGS) }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
-          TG_BUCKET_PREFIX: ${{ secrets.TG_BUCKET_PREFIX }}
-  deploy:
-    if: github.env.WILL_DEPLOY == true
-    runs-on: ubuntu-latest
-    environment: ${{ github.env.ACTIONS_ENVIRONMENT }}
-    needs: [ plan ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@main
-      - name: Authenticate to AWS
-        id: creds
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: us-east-1
-          role-to-assume:  ${{ secrets.GH_IAM_ROLE_ARN }}
-          output-credentials: true
-      - name: Deploy
-        uses: gruntwork-io/terragrunt-action@v2
-        with:
-          tg_version: ${{ env.TG_VERSION }}
-          tf_version: ${{ env.TF_VERSION }}
-          tg_comment: true
-          tg_command: ${{ format('run-all {0} apply', env.APPLY_FLAGS) }}
+          tg_command: format('run-all {0} plan', env.PLAN_FLAGS)
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}


### PR DESCRIPTION
Currently, both Terragrunt plan and Terragrunt apply run as part of the same workflow, `deployment.yaml`. This PR splits them into two reusable workflows for each step, and additionally splits their triggering workflow into two corresponding steps as well. Planning now happens before a PR is merged, and applying happens afterward.