### PR TITLE
Set provider meta-argument and remove variable for personal token

### DIFF
--- a/infra/frontend/modules/service_token/main.tf
+++ b/infra/frontend/modules/service_token/main.tf
@@ -1,6 +1,7 @@
 data "aws_caller_identity" "self" {}
 
 resource "doppler_service_token" "ci_service_token" {
+  provider = doppler.personal
   project = var.project
   config  = var.config
   name    = format("Service_Token_%s-%s", var.service_token_slug, timestamp())

--- a/infra/frontend/modules/service_token/outputs.tf
+++ b/infra/frontend/modules/service_token/outputs.tf
@@ -3,4 +3,3 @@ output "doppler_service_token_secret_id" {
   description = "The id of the AWSSM secret ID that holds the service token value"
   sensitive   = true
 }
-

--- a/infra/frontend/modules/service_token/variables.tf
+++ b/infra/frontend/modules/service_token/variables.tf
@@ -1,9 +1,3 @@
-variable "doppler_personal_token" {
-  description = "This is your Doppler personal token."
-  type        = string
-  sensitive   = true
-  default     = ""
-}
 variable "service_token_slug" {
   description = "This is the slug of the Doppler service token, used both in AWS SM and Doppler"
   type = string


### PR DESCRIPTION
This PR prepares the service token module for when PR #20 is merged. PR #20 creates a Doppler provider configuration with the alias 'personal', which removes the need for the `doppler_personal_token` variable.