### PR TITLE
Use inputs context to determine environment instead of github context

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,7 +34,6 @@ permissions:
 env:
   TG_VERSION: '0.72.5'
   TF_VERSION: '1.10.5'
-  ACTIONS_ENVIRONMENT: ${{ inputs.actions_environment }}
   TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.tg_exclude_dir != '' && format('**/*/oidc, {0}', inputs.tg_exclude_dir) || '**/*/oidc' }} # excluded because it only needs to run once (to set up OIDC provider for Actions to authenticate to AWS)
   TERRAGRUNT_INCLUDE_DIR: ${{ inputs.tg_include_dir }}
   TERRAGRUNT_NON_INTERACTIVE: true
@@ -44,7 +43,7 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: ${{ github.env.ACTIONS_ENVIRONMENT }}
+    environment: ${{ inputs.actions_environment }}
     steps:
       - name: Checkout
         uses: actions/checkout@main

--- a/.github/workflows/plan-trigger.yaml
+++ b/.github/workflows/plan-trigger.yaml
@@ -7,6 +7,7 @@ on:
       - opened
       - reopened
       - synchronize
+  workflow_dispatch:
 
 permissions:
   id-token: write

--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -21,15 +21,13 @@ on:
         type: string
         default: ''
 
-
 permissions:
-  id-token: write
   contents: read
+  id-token: write
 
 env:
   TG_VERSION: '0.72.5'
   TF_VERSION: '1.10.5'
-  ACTIONS_ENVIRONMENT: ${{ inputs.actions_environment }}
   TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.tg_exclude_dir != '' && format('**/*/oidc, {0}', inputs.tg_exclude_dir) || '**/*/oidc' }} # excluded because it only needs to run once (to set up OIDC provider for Actions to authenticate to AWS)
   TERRAGRUNT_INCLUDE_DIR: ${{ inputs.tg_include_dir }}
   TERRAGRUNT_NON_INTERACTIVE: true
@@ -39,7 +37,7 @@ env:
 jobs:
   plan:
     runs-on: ubuntu-latest
-    environment: ${{ github.env.ACTIONS_ENVIRONMENT }}
+    environment: ${{ inputs.actions_environment }}
     steps:
       - name: Checkout
         uses: actions/checkout@main


### PR DESCRIPTION
Branches were not being deployed to the correct environment earlier due to incorrect use of github context. This PR resolves the issue by using inputs context instead.