### PR TITLE
Trigger plan and deploy on root config changes too

### DIFF
--- a/.github/workflows/deploy-trigger.yaml
+++ b/.github/workflows/deploy-trigger.yaml
@@ -22,6 +22,7 @@ jobs:
       be-stage-changes: ${{ steps.changed-files-be-stage.outputs.any_changed }}
       be-prod-changes: ${{ steps.changed-files-be-prod.outputs.any_changed }}
       be-common-changes: ${{ steps.changed-files-be-common.outputs.any_changed }}
+      root-changes: ${{ steps.changed-root.outputs.any_changed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -64,10 +65,15 @@ jobs:
           files_ignore: |
             infra/backend/live/stage/**/**
             infra/backend/live/prod/**/**
+      - name: Get changed files common to all layers
+        id: changed-root
+        uses: tj-actions/changed-files@v45
+        with:
+          files: 'infra/root.hcl'
   trigger-deploy-fe-stage:
     needs: detect-changed
     name: Trigger frontend-stage deploy if needed
-    if: needs.detect-changed.outputs.fe-stage-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true'
+    if: needs.detect-changed.outputs.fe-stage-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true' || needs.detect-changed.outputs.root-changes == 'true'
     uses: nestrr/flock-infra/.github/workflows/deploy.yaml@main
     with:
       actions_environment: "frontend-stage"
@@ -76,7 +82,7 @@ jobs:
   trigger-deploy-fe-prod:
     needs: detect-changed
     name: Trigger frontend-prod deploy if needed
-    if: needs.detect-changed.outputs.fe-prod-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true'
+    if: needs.detect-changed.outputs.fe-prod-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true' || needs.detect-changed.outputs.root-changes == 'true'
     uses: nestrr/flock-infra/.github/workflows/deploy.yaml@main
     with:
       actions_environment: "frontend-prod"
@@ -85,7 +91,7 @@ jobs:
   trigger-deploy-be-stage:
     needs: detect-changed
     name: Trigger backend-stage deploy if needed
-    if: needs.detect-changed.outputs.be-stage-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true'
+    if: needs.detect-changed.outputs.be-stage-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true' || needs.detect-changed.outputs.root-changes == 'true'
     uses: nestrr/flock-infra/.github/workflows/deploy.yaml@main
     with:
       actions_environment: "backend-stage"
@@ -94,7 +100,7 @@ jobs:
   trigger-deploy-be-prod:
     needs: detect-changed
     name: Trigger backend-stage deploy if needed
-    if: needs.detect-changed.outputs.be-prod-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true'
+    if: needs.detect-changed.outputs.be-prod-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true' || needs.detect-changed.outputs.root-changes == 'true'
     uses: nestrr/flock-infra/.github/workflows/deploy.yaml@main
     with:
       actions_environment: "backend-prod"

--- a/.github/workflows/plan-trigger.yaml
+++ b/.github/workflows/plan-trigger.yaml
@@ -24,6 +24,7 @@ jobs:
       be-stage-changes: ${{ steps.changed-files-be-stage.outputs.any_changed }}
       be-prod-changes: ${{ steps.changed-files-be-prod.outputs.any_changed }}
       be-common-changes: ${{ steps.changed-files-be-common.outputs.any_changed }}
+      root-changes: ${{ steps.changed-root.outputs.any_changed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -66,10 +67,15 @@ jobs:
           files_ignore: |
             infra/backend/live/stage/**/**
             infra/backend/live/prod/**/**
+      - name: Get changed files common to all layers
+        id: changed-root
+        uses: tj-actions/changed-files@v45
+        with:
+          files: 'infra/root.hcl'
   trigger-deploy-fe-stage:
     needs: detect-changed
     name: Trigger frontend-stage plan if needed
-    if: needs.detect-changed.outputs.fe-stage-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true'
+    if: needs.detect-changed.outputs.fe-stage-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true' || needs.detect-changed.outputs.root-changes == 'true'
     uses: nestrr/flock-infra/.github/workflows/plan.yaml@main
     with:
       actions_environment: "frontend-stage"
@@ -79,7 +85,7 @@ jobs:
   trigger-deploy-fe-prod:
     needs: detect-changed
     name: Trigger frontend-prod plan if needed
-    if: needs.detect-changed.outputs.fe-prod-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true'
+    if: needs.detect-changed.outputs.fe-prod-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true' || needs.detect-changed.outputs.root-changes == 'true'
     uses: nestrr/flock-infra/.github/workflows/plan.yaml@main
     with:
       actions_environment: "frontend-prod"
@@ -89,7 +95,7 @@ jobs:
   trigger-deploy-be-stage:
     needs: detect-changed
     name: Trigger backend-stage plan if needed
-    if: needs.detect-changed.outputs.be-stage-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true'
+    if: needs.detect-changed.outputs.be-stage-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true' || needs.detect-changed.outputs.root-changes == 'true'
     uses: nestrr/flock-infra/.github/workflows/plan.yaml@main
     with:
       actions_environment: "backend-stage"
@@ -99,7 +105,7 @@ jobs:
   trigger-deploy-be-prod:
     needs: detect-changed
     name: Trigger backend-stage plan if needed
-    if: needs.detect-changed.outputs.be-prod-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true'
+    if: needs.detect-changed.outputs.be-prod-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true' || needs.detect-changed.outputs.root-changes == 'true'
     uses: nestrr/flock-infra/.github/workflows/plan.yaml@main
     with:
       actions_environment: "backend-prod"


### PR DESCRIPTION
Currently Terraform plan and deploy are triggered on all layer-specific configuration changes. This PR ensures they are triggered on root unit configuration changes too.