### PR TITLE
Separate IAM policy from role created by OIDC module

### DIFF
--- a/infra/frontend/modules/oidc/main.tf
+++ b/infra/frontend/modules/oidc/main.tf
@@ -3,14 +3,17 @@ data "aws_caller_identity" "self" {}
 module "oidc_github" {
   source              = "git::https://github.com/unfunco/terraform-aws-oidc-github.git?ref=f664e8f6002b11b5c206f1fb3cf0377ea6a033ae"
   github_repositories = var.allowed_repos_branches
-  iam_role_inline_policies = {
-    "tg_policy" : data.aws_iam_policy_document.iam_policy.json
-  }
-  enabled = var.enable_resource_creation
-  create_oidc_provider = var.enable_oidc_provider_creation
+  iam_role_policy_arns = [
+    aws_iam_policy.iam_policy.arn
+  ]
 }
 
-data "aws_iam_policy_document" "iam_policy" {
+resource "aws_iam_policy" "iam_policy" {
+  name = "oidc_policy"
+  policy = data.aws_iam_policy_document.iam_policy_doc.json
+}
+
+data "aws_iam_policy_document" "iam_policy_doc" {
   statement {
     sid = "AllowAllDynamoDBActionsOnAllTerragruntTables"
     actions = [
@@ -26,6 +29,37 @@ data "aws_iam_policy_document" "iam_policy" {
     resources = [
       "arn:aws:s3:::terragrunt*",
       "arn:aws:s3:::terragrunt*/*"
+    ]
+  }
+  statement {
+    sid     = "AllowManageKey"
+    actions = [
+      "kms:Create*",
+      "kms:Put*",
+      "kms:Delete*"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+  statement {
+    sid     = "AllowManageSecret"
+    actions = [
+      "secretsmanager:Create*",
+      "secretsmanager:Put*",
+      "secretsmanager:Delete*"
+    ]
+    resources = [
+      "arn:aws:secretsmanager::::*"
+    ]
+  }
+  statement {
+    sid     = "AllowCreatePolicy"
+    actions = [
+      "iam:CreatePolicy"
+    ]
+    resources = [
+      "arn:aws:secretsmanager::::*"
     ]
   }
 }

--- a/infra/frontend/modules/oidc/main.tf
+++ b/infra/frontend/modules/oidc/main.tf
@@ -6,6 +6,7 @@ module "oidc_github" {
   iam_role_policy_arns = [
     aws_iam_policy.iam_policy.arn
   ]
+  enabled = var.enable_resource_creation
 }
 
 resource "aws_iam_policy" "iam_policy" {


### PR DESCRIPTION
This PR creates a separate policy for ephemeral role permissions and attaches its ARN to the role created by the OIDC module. This way, the policies can be updated without needing to re-run the module or re-create the role.