### PR TITLE
Update OIDC module to self-exclude unless feature flag is provided

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,7 +34,7 @@ permissions:
 env:
   TG_VERSION: '0.72.5'
   TF_VERSION: '1.10.5'
-  TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.tg_exclude_dir != '' && format('**/*/oidc, {0}', inputs.tg_exclude_dir) || '**/*/oidc' }} # excluded because it only needs to run once (to set up OIDC provider for Actions to authenticate to AWS)
+  TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.tg_exclude_dir }}
   TERRAGRUNT_INCLUDE_DIR: ${{ inputs.tg_include_dir }}
   TERRAGRUNT_NON_INTERACTIVE: true
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -28,7 +28,7 @@ permissions:
 env:
   TG_VERSION: '0.72.5'
   TF_VERSION: '1.10.5'
-  TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.tg_exclude_dir != '' && format('**/*/oidc, {0}', inputs.tg_exclude_dir) || '**/*/oidc' }} # excluded because it only needs to run once (to set up OIDC provider for Actions to authenticate to AWS)
+  TERRAGRUNT_EXCLUDE_DIR: ${{ inputs.tg_exclude_dir }}
   TERRAGRUNT_INCLUDE_DIR: ${{ inputs.tg_include_dir }}
   TERRAGRUNT_NON_INTERACTIVE: true
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/infra/frontend/live/stage/oidc/.terraform.lock.hcl
+++ b/infra/frontend/live/stage/oidc/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/dopplerhq/doppler" {
+  version     = "1.13.0"
+  constraints = "~> 1.13.0"
+  hashes = [
+    "h1:aZYITIkiL1/4JZlkyznXekp8Cr/i4FRrMr1GFY7psO8=",
+    "zh:07f501e4d90b63e044afba3959914db6ee6a318b431400b573a948e19ee93f6c",
+    "zh:0a8e15619065b87067a16d440033f1f3fdb97e872e2bebc91620a5b7a66ed558",
+    "zh:18029f97da036fd8d3ad3bb920802eabdd674f5462a56135c14ae3818bb5fa7c",
+    "zh:38da813b6311afe2f1615ac0f6171cf466cac149c1dea4a82ea434c9cc7cc0e7",
+    "zh:4499eb18120f2d44f8e3bd8229845d6184380323d6b91dc58ca99195ba0c7f9b",
+    "zh:5ba79177b58f6f019ee5b3cce78cdc90295e155df593aeb2d9220565f8d78eb5",
+    "zh:9d8c4dbcaba45e98ae6cfa40d847b0c1fe97ced6c40a474d08e50405189cc113",
+    "zh:a727f65bec2213855309e1aa79e2ebfa6620d3f2830dd61e15b5c7e8645a7c9a",
+    "zh:c0941606cd655bb3165b51efb594205517b422d8ca2b75caad41e0917447401e",
+    "zh:c5d9d2d55f5b77fc2cfcc8d3bca53d9bf5288f590d192132be7d37a34f0b419d",
+    "zh:c95ed84df0f6aa822f8b0c6b12b80d94ab569bc4bca2b7f7c4e9fd7c24d3f0ab",
+    "zh:cd05ac90242566ced97fbd52a84f3619dae4c89b085699c088d7f34c5841f350",
+    "zh:d1c92443af7a7a7299081a91c4a8236f639b5270567683bde02db4311f99eb0f",
+    "zh:e9da7c0de47969de83d3328add356307a2d3eb871392b87c7de96d25d67087ef",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.84.0"
   constraints = ">= 4.0.0"

--- a/infra/frontend/live/stage/oidc/terragrunt.hcl
+++ b/infra/frontend/live/stage/oidc/terragrunt.hcl
@@ -17,13 +17,32 @@ include "common" {
   # We want to reference the variables from the included config in this configuration, so we expose it.
   expose = true
 }
-
+# Create feature so that resource creation is only enabled if this feature is explicitly set to true.
+feature "create_oidc_resources" {
+  default = false
+}
+# Create feature so that change runs are only enabled if this feature is explicitly set to true.
+feature "run_changes" {
+  default = false
+}
 # Configure the version of the module to use in this environment. This allows you to promote new versions one
 # environment at a time (e.g., qa -> stage -> prod).
 terraform {
-  source = "${include.common.locals.base_source_url}?ref=v0.1.0-beta.3"
+  source = "${include.common.locals.base_source_url}?ref=v0.1.0-beta.35"
+  before_hook "prevent_creation" {
+    commands = ["apply", "destroy", "plan"]
+    execute  = feature.run_changes.value ? ["bash", "-c", "echo 'Creating resources.'"] : ["bash", "-c", "echo 'Modifying OIDC setup is skipped, as run_changes feature is set to false.' && exit 1"]
+  }
+}
+# Exclude this unit from run queue if run-all is being used
+exclude {
+    if = !feature.run_changes.value
+    actions = ["apply", "destroy", "plan"]
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
 # We don't need to override any of the common parameters for this environment, so we don't specify any inputs.
 # ----------------------------------------------------------------------------------------------------------------
+inputs = {
+  enable_resource_creation = feature.create_oidc_resources.value
+}

--- a/infra/frontend/live/stage/oidc/terragrunt.hcl
+++ b/infra/frontend/live/stage/oidc/terragrunt.hcl
@@ -40,9 +40,6 @@ exclude {
     actions = ["apply", "destroy", "plan"]
 }
 
-# ---------------------------------------------------------------------------------------------------------------------
-# We don't need to override any of the common parameters for this environment, so we don't specify any inputs.
-# ----------------------------------------------------------------------------------------------------------------
 inputs = {
   enable_resource_creation = feature.create_oidc_resources.value
 }


### PR DESCRIPTION
Previously the OIDC module had to explicitly be excluded from the deploy and plan workflows. Now its corresponding unit has been updated so the module is excluded automatically unless the `run_changes` feature flag is set to true.