### PR TITLE
Prevent AWSSM from attempting to create a duplicate secret

### DIFF
--- a/infra/frontend/modules/service_token/main.tf
+++ b/infra/frontend/modules/service_token/main.tf
@@ -57,9 +57,6 @@ resource "aws_secretsmanager_secret" "doppler_service_token_secret" {
   tags = {
     "created" : timestamp()
   }
-  lifecycle {
-    create_before_destroy = true
-  }
   depends_on = [aws_kms_key_policy.cmk_admin_policy]
 }
 


### PR DESCRIPTION
Currently the secret resource in service_token module contains a `create_before_destroy` block, which causes an issue when it needs to be recreated - as no two secrets may share the same name. So, this PR removes that block.