### PR TITLE
Disable failing cleanup step, reference env variable instead of hard-coding secret name

### DIFF
--- a/.github/workflows/rotate-doppler.yaml
+++ b/.github/workflows/rotate-doppler.yaml
@@ -47,21 +47,21 @@ jobs:
                --header 'content-type: application/json' \
                --data '{"token":"$DOPPLER_TOKEN"}'
         env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_PT }}
-      - name: Delete Doppler token secret from environment
-        if: ${{ env.DOPPLER_TOKEN != '' }}
-        uses: octokit/request-action@v2.x
-        id: delete_secret
-        with:
-          route: ${{ format('DELETE /repos/nestrr/flock-infra/environments/{0}/secrets/{1}', env.ACTIONS_ENVIRONMENT, 'DOPPLER_PT') }}
-          owner: nestrr
-          repo: flock-infra
-          environment_name: ${{ env.ACTIONS_ENVIRONMENT }}
-          secret_name: "DOPPLER_PT"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_PT }}
-          ACTIONS_ENVIRONMENT: ${{ format('{0}-{1}', inputs.layer, inputs.env_config) }}
+          DOPPLER_TOKEN: ${{ secrets[vars.DOPPLER_TOKEN_SECRET_NAME] }}
+#      - name: Delete Doppler token secret from environment
+#        if: ${{ env.DOPPLER_TOKEN != '' }}
+#        uses: octokit/request-action@v2.x
+#        id: delete_secret
+#        with:
+#          route: ${{ format('DELETE /repos/nestrr/flock-infra/environments/{0}/secrets/{1}', env.ACTIONS_ENVIRONMENT, 'DOPPLER_PT') }}
+#          owner: nestrr
+#          repo: flock-infra
+#          environment_name: ${{ env.ACTIONS_ENVIRONMENT }}
+#          secret_name: "DOPPLER_PT"
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          DOPPLER_TOKEN: ${{ secrets.DOPPLER_PT }}
+#          ACTIONS_ENVIRONMENT: ${{ format('{0}-{1}', inputs.layer, inputs.env_config) }}
       - name: Disable this workflow
         uses: octokit/request-action@v2.x
         id: disable_workflow


### PR DESCRIPTION
This PR temporarily disables the failing 2nd step of the cleanup job. Deleting the Doppler token secret would require more permissions than the default `GITHUB_TOKEN` provides. This step will be reinstated following the creation of a fine-grained token that allows this action to happen.

Additionally, this PR replaces the hardcoded environment secret name (`DOPPLER_PT`) with the repository-level environment variable `DOPPLER_TOKEN_SECRET_NAME`.