### PR TITLE
Create repository-level variable to track latest release's tag

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -66,3 +66,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
           TG_BUCKET_PREFIX: ${{ secrets.TG_BUCKET_PREFIX }}
           DOPPLER_PT: ${{ secrets.DOPPLER_PT }} # will be empty unless the token is being refreshed
+          LATEST_TAG: ${{ vars.LATEST_TAG }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -66,4 +66,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
           TG_BUCKET_PREFIX: ${{ secrets.TG_BUCKET_PREFIX }}
           DOPPLER_PT: ${{ secrets.DOPPLER_PT }} # will be empty unless the token is being refreshed
-          LATEST_TAG: ${{ vars.LATEST_TAG }}
+          LATEST_RELEASE_TAG: ${{ vars.LATEST_RELEASE_TAG }}

--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -59,4 +59,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
           TG_BUCKET_PREFIX: ${{ secrets.TG_BUCKET_PREFIX }}
-          LATEST_TAG: ${{ vars.LATEST_TAG }}
+          LATEST_RELEASE_TAG: ${{ vars.LATEST_RELEASE_TAG }}

--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -59,3 +59,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
           TG_BUCKET_PREFIX: ${{ secrets.TG_BUCKET_PREFIX }}
+          LATEST_TAG: ${{ vars.LATEST_TAG }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
+    outputs:
+      new_tag: ${{ steps.new_release.outputs.new_tag }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -20,8 +22,22 @@ jobs:
 
     - name: Bump version and push tag
       uses: anothrNick/github-tag-action@v1
+      id: new_release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # if you don't want to set write permissions use a PAT token
         WITH_V: true
         PRERELEASE: true
         ref: ${{github.sha}}
+  bump-latest-ref:
+    needs: build
+    name: Bump LATEST_RELEASE_TAG repository-level environment variable
+    runs-on: ubuntu-latest
+    steps:
+      - uses: octokit/request-action@v2.x
+        id: bump_env_var
+        with:
+          route: 'PATCH /repos/nestrr/flock-infra/actions/variables/LATEST_RELEASE_TAG'
+          name: LATEST_RELEASE_TAG
+          value: ${{ needs.build.outputs.new_tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.POST_RELEASE_TOKEN }}

--- a/infra/frontend/live/stage/service_token/terragrunt.hcl
+++ b/infra/frontend/live/stage/service_token/terragrunt.hcl
@@ -26,7 +26,7 @@ feature "modify_service_token" {
 # Configure the version of the module to use in this environment. This allows you to promote new versions one
 # environment at a time (e.g., qa -> stage -> prod).
 terraform {
-  source = "${include.common.locals.base_source_url}?ref=v0.1.0-beta.42"
+  source = "${include.common.locals.base_source_url}?ref=${get_env("LATEST_RELEASE_TAG", "")}"
   before_hook "prevent_mod_token" {
     commands = ["apply", "destroy", "plan"]
     execute  = feature.modify_service_token.value ? ["bash", "-c", "echo 'Modifying service token.'"] : ["bash", "-c", "echo 'Modifying service token is skipped, as modify_service_token feature is set to false.' && exit 1"]


### PR DESCRIPTION
Currently, there is a lot of noise in our PR history because the staging environment needs the latest version of the module, and the only way to make this happen is to create a PR (like #43). Instead, this PR makes it so the latest release tag is stored in a repository-level environment variable, which is injected into Terragrunt runs as an environment variable and used by staging units.