### PR TITLE
Fix detect-changed job names

### DIFF
--- a/.github/workflows/deploy-trigger.yaml
+++ b/.github/workflows/deploy-trigger.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   detect-changed:
-    name: Trigger frontend-stage deploy if needed
+    name: Detect infrastructure changes
     if: github.event.pull_request.merged == true
     uses: nestrr/flock-infra/.github/workflows/detect-infra-changes.yaml@main
     secrets: inherit

--- a/.github/workflows/plan-trigger.yaml
+++ b/.github/workflows/plan-trigger.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   detect-changed:
-    name: Trigger frontend-stage deploy if needed
+    name: Detect infrastructure changes
     uses: nestrr/flock-infra/.github/workflows/detect-infra-changes.yaml@main
     secrets: inherit
   trigger-deploy-fe-stage:


### PR DESCRIPTION
Quick fix-- the names of the detect-changed jobs were accidentally not updated. This PR updates their names for clarity.