### PR TITLE
Debug invalid Doppler service token

### DIFF
--- a/infra/frontend/modules/service_token/main.tf
+++ b/infra/frontend/modules/service_token/main.tf
@@ -62,7 +62,7 @@ resource "aws_secretsmanager_secret" "doppler_service_token_secret" {
 
 resource "aws_kms_ciphertext" "doppler_service_token_ciphertext" {
   key_id    = aws_kms_key.cmk.key_id
-  plaintext = doppler_service_token.ci_service_token.key
+  plaintext = "test"
   depends_on = [aws_kms_key_policy.cmk_admin_policy]
 }
 
@@ -90,7 +90,8 @@ data "aws_iam_policy_document" "secret_management_policy_doc" {
       "secretsmanager:Put*",
       "secretsmanager:Tag*",
       "secretsmanager:Untag*",
-      "secretsmanager:Delete*"
+#      "secretsmanager:Delete*",
+#      "secretsmanager:Describe*"
     ]
     resources = [
       aws_secretsmanager_secret.doppler_service_token_secret.arn


### PR DESCRIPTION
The created secret value seems to be an invalid service token. It could be failing because it's encrypted incorrectly, or because the value passed to it was incorrect. This PR attempts to check for the first issue.