### PR TITLE
Test setting secret string directly

### DIFF
--- a/infra/frontend/modules/service_token/main.tf
+++ b/infra/frontend/modules/service_token/main.tf
@@ -60,12 +60,6 @@ resource "aws_secretsmanager_secret" "doppler_service_token_secret" {
   depends_on = [aws_kms_key_policy.cmk_admin_policy]
 }
 
-resource "aws_kms_ciphertext" "doppler_service_token_ciphertext" {
-  key_id    = aws_kms_key.cmk.key_id
-  plaintext = "test"
-  depends_on = [aws_kms_key_policy.cmk_admin_policy]
-}
-
 resource "aws_secretsmanager_secret_policy" "secret_management_policy" {
   secret_arn = aws_secretsmanager_secret.doppler_service_token_secret.arn
   policy     = data.aws_iam_policy_document.secret_management_policy_doc.json
@@ -101,6 +95,6 @@ data "aws_iam_policy_document" "secret_management_policy_doc" {
 
 resource "aws_secretsmanager_secret_version" "doppler_personal_token_secret_val" {
   secret_id     = aws_secretsmanager_secret.doppler_service_token_secret.id
-  secret_string = aws_kms_ciphertext.doppler_service_token_ciphertext.ciphertext_blob
+  secret_string = "test" #doppler_service_token.ci_service_token.key
   depends_on = [aws_secretsmanager_secret_policy.secret_management_policy]
 }


### PR DESCRIPTION
Following up on #52, testing showed that even with `test` as the secret value passed to terraform, the secret in AWSSM was an unintelligible set of characters. The hunch is that passing the ciphertext blob is not necessary. This PR tests that change.