### PR TITLE
Expose Terragrunt config changes

### DIFF
--- a/.github/workflows/deploy-trigger.yaml
+++ b/.github/workflows/deploy-trigger.yaml
@@ -20,7 +20,7 @@ jobs:
   trigger-deploy-fe-stage:
     needs: detect-changed
     name: Trigger frontend-stage deploy if needed
-    if: needs.detect-changed.outputs.fe-stage-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true' || needs.detect-changed.outputs.root-changes == 'true'
+    if: needs.detect-changed.outputs.fe-stage-changes == 'true'
     uses: nestrr/flock-infra/.github/workflows/deploy.yaml@main
     with:
       actions_environment: "frontend-stage"
@@ -29,7 +29,7 @@ jobs:
   trigger-deploy-fe-prod:
     needs: detect-changed
     name: Trigger frontend-prod deploy if needed
-    if: needs.detect-changed.outputs.fe-prod-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true' || needs.detect-changed.outputs.root-changes == 'true'
+    if: needs.detect-changed.outputs.fe-prod-changes == 'true'
     uses: nestrr/flock-infra/.github/workflows/deploy.yaml@main
     with:
       actions_environment: "frontend-prod"
@@ -38,7 +38,7 @@ jobs:
   trigger-deploy-be-stage:
     needs: detect-changed
     name: Trigger backend-stage deploy if needed
-    if: needs.detect-changed.outputs.be-stage-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true' || needs.detect-changed.outputs.root-changes == 'true'
+    if: needs.detect-changed.outputs.be-stage-changes == 'true'
     uses: nestrr/flock-infra/.github/workflows/deploy.yaml@main
     with:
       actions_environment: "backend-stage"
@@ -47,7 +47,7 @@ jobs:
   trigger-deploy-be-prod:
     needs: detect-changed
     name: Trigger backend-stage deploy if needed
-    if: needs.detect-changed.outputs.be-prod-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true' || needs.detect-changed.outputs.root-changes == 'true'
+    if: needs.detect-changed.outputs.be-prod-changes == 'true'
     uses: nestrr/flock-infra/.github/workflows/deploy.yaml@main
     with:
       actions_environment: "backend-prod"

--- a/.github/workflows/detect-infra-changes.yaml
+++ b/.github/workflows/detect-infra-changes.yaml
@@ -1,7 +1,19 @@
 name: Detect Terragrunt config changes
 on:
   workflow_call:
-
+    outputs:
+      fe-stage-changes:
+        description: "Changed files that affect frontend stage environment"
+        value: ${{ jobs.detect-changed.outputs.fe-stage-changes || jobs.detect-changed.outputs.fe-common-changes }}
+      be-stage-changes:
+        description: "Changed files that affect backend stage environment"
+        value: ${{ jobs.detect-changed.outputs.fe-stage-changes || jobs.detect-changed.outputs.be-common-changes }}
+      fe-prod-changes:
+        description: "Changed files that affect frontend prod environment"
+        value: ${{ jobs.detect-changed.outputs.fe-prod-changes  || jobs.detect-changed.outputs.fe-common-changes }}
+      be-prod-changes:
+        description: "Changed files that affect backend prod environment"
+        value: ${{ jobs.detect-changed.outputs.be-prod-changes || jobs.detect-changed.outputs.be-common-changes }}
 permissions:
   contents: read
 jobs:
@@ -10,11 +22,10 @@ jobs:
     outputs:
       fe-stage-changes: ${{ steps.changed-files-fe-stage.outputs.any_changed }}
       fe-prod-changes: ${{ steps.changed-files-fe-prod.outputs.any_changed }}
-      fe-common-changes: ${{ steps.changed-files-fe-common.outputs.any_changed }}
+      fe-common-changes: ${{ steps.changed-files-fe-common.outputs.any_changed || steps.changed-root.outputs.any_changed }}
       be-stage-changes: ${{ steps.changed-files-be-stage.outputs.any_changed }}
       be-prod-changes: ${{ steps.changed-files-be-prod.outputs.any_changed }}
-      be-common-changes: ${{ steps.changed-files-be-common.outputs.any_changed }}
-      root-changes: ${{ steps.changed-root.outputs.any_changed }}
+      be-common-changes: ${{ steps.changed-files-be-common.outputs.any_changed || steps.changed-root.outputs.any_changed }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/plan-trigger.yaml
+++ b/.github/workflows/plan-trigger.yaml
@@ -22,7 +22,7 @@ jobs:
   trigger-deploy-fe-stage:
     needs: detect-changed
     name: Trigger frontend-stage plan if needed
-    if: needs.detect-changed.outputs.fe-stage-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true' || needs.detect-changed.outputs.root-changes == 'true'
+    if: needs.detect-changed.outputs.fe-stage-changes == 'true'
     uses: nestrr/flock-infra/.github/workflows/plan.yaml@main
     with:
       actions_environment: "frontend-stage"
@@ -31,7 +31,7 @@ jobs:
   trigger-deploy-fe-prod:
     needs: detect-changed
     name: Trigger frontend-prod plan if needed
-    if: needs.detect-changed.outputs.fe-prod-changes == 'true' || needs.detect-changed.outputs.fe-common-changes == 'true' || needs.detect-changed.outputs.root-changes == 'true'
+    if: needs.detect-changed.outputs.fe-prod-changes == 'true'
     uses: nestrr/flock-infra/.github/workflows/plan.yaml@main
     with:
       actions_environment: "frontend-prod"
@@ -40,7 +40,7 @@ jobs:
   trigger-deploy-be-stage:
     needs: detect-changed
     name: Trigger backend-stage plan if needed
-    if: needs.detect-changed.outputs.be-stage-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true' || needs.detect-changed.outputs.root-changes == 'true'
+    if: needs.detect-changed.outputs.be-stage-changes == 'true'
     uses: nestrr/flock-infra/.github/workflows/plan.yaml@main
     with:
       actions_environment: "backend-stage"
@@ -49,7 +49,7 @@ jobs:
   trigger-deploy-be-prod:
     needs: detect-changed
     name: Trigger backend-stage plan if needed
-    if: needs.detect-changed.outputs.be-prod-changes == 'true' || needs.detect-changed.outputs.be-common-changes == 'true' || needs.detect-changed.outputs.root-changes == 'true'
+    if: needs.detect-changed.outputs.be-prod-changes == 'true'
     uses: nestrr/flock-infra/.github/workflows/plan.yaml@main
     with:
       actions_environment: "backend-prod"


### PR DESCRIPTION
After #56's checks ran, it was clear that the reusable workflow used to detect infrastructure changes was silently failing. Upon further attention, it turned out that the workflow was missing its `outputs` section. This PR adds them in and simplifies the checks in trigger workflows.