### PR TITLE
Use ref argument to plan based on last commit, not default branch

### DIFF
--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
+        with:
+          ref: ${{ github.sha }}
       - name: Authenticate to AWS
         id: creds
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
Currently the Terragrunt plan workflow checks out the default branch of `flock-infra` on new PRs, so it never plans the changes inside the PRs themselves. This PR fixes that by passing the ref argument to the checkout action.