### PR TITLE
Try using head_ref to get PR branch's changes instead

### DIFF
--- a/.github/workflows/plan-trigger.yaml
+++ b/.github/workflows/plan-trigger.yaml
@@ -27,6 +27,7 @@ jobs:
     with:
       actions_environment: "frontend-stage"
       tg_include_dir: "infra/frontend/live/stage"
+      head_ref: ${{ github.head_ref }}
     secrets: inherit
   trigger-deploy-fe-prod:
     needs: detect-changed
@@ -36,6 +37,7 @@ jobs:
     with:
       actions_environment: "frontend-prod"
       tg_include_dir: "infra/frontend/live/prod"
+      head_ref: ${{ github.head_ref }}
     secrets: inherit
   trigger-deploy-be-stage:
     needs: detect-changed
@@ -45,6 +47,7 @@ jobs:
     with:
       actions_environment: "backend-stage"
       tg_include_dir: "infra/backend/live/stage"
+      head_ref: ${{ github.head_ref }}
     secrets: inherit
   trigger-deploy-be-prod:
     needs: detect-changed
@@ -54,4 +57,5 @@ jobs:
     with:
       actions_environment: "backend-prod"
       tg_include_dir: "infra/backend/live/prod"
+      head_ref: ${{ github.head_ref }}
     secrets: inherit

--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
+        with:
+          ref: ${{ github.sha }}
       - name: Authenticate to AWS
         id: creds
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
         default: ''
+      head_ref:
+        description: 'The head_ref or source branch of the pull request.'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -42,7 +46,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@main
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.head_ref }}
       - name: Authenticate to AWS
         id: creds
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
Follows up on #58 - which still fails. `head_ref` seems to be the way to go, but it is only available inside the workflow triggered by pull_request. So an extra input is added in plan.yaml too.