### PR TITLE
Include all subdirectories of tg_include_dir

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/deploy-trigger.yaml
+++ b/.github/workflows/deploy-trigger.yaml
@@ -24,7 +24,7 @@ jobs:
     uses: nestrr/flock-infra/.github/workflows/deploy.yaml@main
     with:
       actions_environment: "frontend-stage"
-      tg_include_dir: "infra/frontend/live/stage"
+      tg_include_dir: "infra/frontend/live/stage/**"
     secrets: inherit
   trigger-deploy-fe-prod:
     needs: detect-changed
@@ -33,7 +33,7 @@ jobs:
     uses: nestrr/flock-infra/.github/workflows/deploy.yaml@main
     with:
       actions_environment: "frontend-prod"
-      tg_include_dir: "infra/frontend/live/prod"
+      tg_include_dir: "infra/frontend/live/prod/**"
     secrets: inherit
   trigger-deploy-be-stage:
     needs: detect-changed
@@ -42,7 +42,7 @@ jobs:
     uses: nestrr/flock-infra/.github/workflows/deploy.yaml@main
     with:
       actions_environment: "backend-stage"
-      tg_include_dir: "infra/backend/live/stage"
+      tg_include_dir: "infra/backend/live/stage/**"
     secrets: inherit
   trigger-deploy-be-prod:
     needs: detect-changed
@@ -51,5 +51,5 @@ jobs:
     uses: nestrr/flock-infra/.github/workflows/deploy.yaml@main
     with:
       actions_environment: "backend-prod"
-      tg_include_dir: "infra/backend/live/prod"
+      tg_include_dir: "infra/backend/live/prod/**"
     secrets: inherit

--- a/.github/workflows/plan-trigger.yaml
+++ b/.github/workflows/plan-trigger.yaml
@@ -26,7 +26,7 @@ jobs:
     uses: nestrr/flock-infra/.github/workflows/plan.yaml@main
     with:
       actions_environment: "frontend-stage"
-      tg_include_dir: "infra/frontend/live/stage"
+      tg_include_dir: "infra/frontend/live/stage/**"
     secrets: inherit
   trigger-deploy-fe-prod:
     needs: detect-changed
@@ -35,7 +35,7 @@ jobs:
     uses: nestrr/flock-infra/.github/workflows/plan.yaml@main
     with:
       actions_environment: "frontend-prod"
-      tg_include_dir: "infra/frontend/live/prod"
+      tg_include_dir: "infra/frontend/live/prod/**"
     secrets: inherit
   trigger-deploy-be-stage:
     needs: detect-changed
@@ -44,7 +44,7 @@ jobs:
     uses: nestrr/flock-infra/.github/workflows/plan.yaml@main
     with:
       actions_environment: "backend-stage"
-      tg_include_dir: "infra/backend/live/stage"
+      tg_include_dir: "infra/backend/live/stage/**"
     secrets: inherit
   trigger-deploy-be-prod:
     needs: detect-changed
@@ -53,5 +53,5 @@ jobs:
     uses: nestrr/flock-infra/.github/workflows/plan.yaml@main
     with:
       actions_environment: "backend-prod"
-      tg_include_dir: "infra/backend/live/prod"
+      tg_include_dir: "infra/backend/live/prod/**"
     secrets: inherit


### PR DESCRIPTION
Currently, PR checks silently fail because the terragrunt actions do not check subdirectories provided by plan- or deploy-trigger. This PR resolves the issue by adding /** at the end of the directory name.
