### PR TITLE
Defer web app deployment due to Vercel Pro costs

### DIFF
--- a/infra/frontend/live/stage/web_app/terragrunt.hcl
+++ b/infra/frontend/live/stage/web_app/terragrunt.hcl
@@ -18,7 +18,7 @@ include "common" {
   expose = true
 }
 
-# Create feature so that service token is only modified if this feature is explicitly set to true.
+# Create feature so that deployment only happens if this feature is explicitly set to true.
 feature "deploy" {
   default = false
 }

--- a/infra/frontend/live/stage/web_app/terragrunt.hcl
+++ b/infra/frontend/live/stage/web_app/terragrunt.hcl
@@ -13,9 +13,14 @@ include "root" {
 # Include the common configuration for the component. The common configuration contains settings that are common
 # for the component across all environments.
 include "common" {
-  path = "${dirname(find_in_parent_folders("root.hcl"))}/frontend/live/common/web_app.hcl"
+  path   = "${dirname(find_in_parent_folders("root.hcl"))}/frontend/live/common/web_app.hcl"
   # We want to reference the variables from the included config in this configuration, so we expose it.
   expose = true
+}
+
+# Create feature so that service token is only modified if this feature is explicitly set to true.
+feature "deploy" {
+  default = false
 }
 
 
@@ -23,6 +28,19 @@ include "common" {
 # environment at a time (e.g., qa -> stage -> prod).
 terraform {
   source = "${include.common.locals.base_source_url}?ref=${get_env("LATEST_RELEASE_TAG", "")}"
+  before_hook "prevent_deploy" {
+    commands = ["apply", "destroy", "plan"]
+    execute  = feature.deploy.value ? ["bash", "-c", "echo 'Deploying web app.'"] : [
+      "bash", "-c", "echo 'Deployment of web app is skipped, as deploy feature is set to false.' && exit 1"
+    ]
+  }
+}
+
+
+# Exclude this unit from run queue if run-all is being used
+exclude {
+  if      = !feature.deploy.value
+  actions = ["apply", "destroy", "plan"]
 }
 
 # No inputs specified, as all are determined by includes.


### PR DESCRIPTION
After attempting to deploy to Vercel, it was discovered that one [cannot deploy from a GitHub organization on the free plan.](https://gist.github.com/ky28059/1c9af929a9030105da8cf00006b50484).
I may attempt to try the gist later, but for now it is a non-issue. When deployment time comes around in a few weeks, I plan to upgrade to Pro and run this unit then.
