### PR TITLE
Validate web app module by deploying to personal account for now

### DIFF
--- a/infra/frontend/live/stage/web_app/terragrunt.hcl
+++ b/infra/frontend/live/stage/web_app/terragrunt.hcl
@@ -18,29 +18,10 @@ include "common" {
   expose = true
 }
 
-# Create feature so that deployment only happens if this feature is explicitly set to true.
-feature "deploy" {
-  default = false
-}
-
-
 # Configure the version of the module to use in this environment. This allows you to promote new versions one
 # environment at a time (e.g., qa -> stage -> prod).
 terraform {
   source = "${include.common.locals.base_source_url}?ref=${get_env("LATEST_RELEASE_TAG", "")}"
-  before_hook "prevent_deploy" {
-    commands = ["apply", "destroy", "plan"]
-    execute  = feature.deploy.value ? ["bash", "-c", "echo 'Deploying web app.'"] : [
-      "bash", "-c", "echo 'Deployment of web app is skipped, as deploy feature is set to false.' && exit 1"
-    ]
-  }
-}
-
-
-# Exclude this unit from run queue if run-all is being used
-exclude {
-  if      = !feature.deploy.value
-  actions = ["apply", "destroy", "plan"]
 }
 
 # No inputs specified, as all are determined by includes.

--- a/infra/frontend/modules/web_app/main.tf
+++ b/infra/frontend/modules/web_app/main.tf
@@ -9,7 +9,8 @@ resource "vercel_project" "vercel_app" {
   framework      = "nextjs"
   git_repository = {
     type = "github"
-    repo = "nestrr/flock-frontend"
+    # TODO: change to Nestrr-owned repo when ready to deploy. This also requires changing the Vercel API key in Doppler.
+    repo = "maryam-khan-dev/flock-frontend"
   }
   serverless_function_region = "pdx1"
 }
@@ -26,9 +27,8 @@ resource "vercel_project_domain" "example" {
 # A redirect of a domain name to a second domain name.
 # The status_code can optionally be controlled.
 resource "vercel_project_domain" "example_redirect" {
-  project_id = vercel_project.vercel_app.id
-  domain     = "www.nestrr.io"
-
+  project_id           = vercel_project.vercel_app.id
+  domain               = "www.nestrr.io"
   redirect             = vercel_project_domain.example.domain
   redirect_status_code = 307
 }


### PR DESCRIPTION
In #62, the web app deployment was disabled unless a feature was explicitly set otherwise. That was because Vercel prevents Hobby plans from deploying a repository from a GitHub organization. Since this app is still in development, it did not make sense to switch to a paid plan yet. So as a workaround, this PR directs Terraform to deploy a fork of the flock-frontend repository on the personal account. The fork will be kept up to date with the GitHub [Pull](https://github.com/wei/pull) app. 
