### PR TITLE
Fix environment variable resource provisioning

### DIFF
--- a/infra/frontend/modules/web_app/main.tf
+++ b/infra/frontend/modules/web_app/main.tf
@@ -36,7 +36,7 @@ resource "vercel_project_domain" "example_redirect" {
 resource "vercel_project_environment_variables" "vercel_app_envs" {
   project_id = vercel_project.vercel_app.id
   variables  = [
-    for secret_name, secret_value in keys(data.doppler_secrets.this.map) :
+    for secret_name, secret_value in data.doppler_secrets.this.map :
     {
       key       = secret_name,
       value     = secret_value,


### PR DESCRIPTION
This PR addresses the failed deployment after #63 was merged. Since the environment variable resource loops over the keys in the Doppler secrets map, the value of secret_name ends up being the index - as the keys of the map are a list.
