### PR TITLE
Disable web app unit due to Vercel provider bug

### DIFF
--- a/infra/frontend/live/stage/web_app/terragrunt.hcl
+++ b/infra/frontend/live/stage/web_app/terragrunt.hcl
@@ -17,11 +17,23 @@ include "common" {
   # We want to reference the variables from the included config in this configuration, so we expose it.
   expose = true
 }
+# BUG: Terraform provider for Vercel fails to update environment variables resource properly.
+# @see https://github.com/vercel/terraform-provider-vercel/issues/262
+# The deploy feature is a temporary workaround to exclude web app infra deployments until Vercel's provider fixes this issue.
+feature "deploy" {
+  default = "false"
+}
+
+exclude {
+  if      = !feature.deploy.value
+  actions = ["apply", "destroy", "plan"]
+}
 
 # Configure the version of the module to use in this environment. This allows you to promote new versions one
 # environment at a time (e.g., qa -> stage -> prod).
 terraform {
   source = "${include.common.locals.base_source_url}?ref=${get_env("LATEST_RELEASE_TAG", "")}"
 }
+
 
 # No inputs specified, as all are determined by includes.


### PR DESCRIPTION
Vercel's provider fails to update the environment variable resource correctly. See [issue 262](https://github.com/vercel/terraform-provider-vercel/issues/262) on this. To prevent noise in deployments, the web app unit is temporarily disabled using the "deploy" feature, so that it will not be redeployed unless explicitly specified otherwise.
