### PR TITLE
Add Hetzner public key env var to deploy and plan workflows

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -67,3 +67,4 @@ jobs:
           TERRAGRUNT_INCLUDE_DIR: ${{ inputs.tg_include_dir }}
           TERRAGRUNT_NON_INTERACTIVE: true
           APPLY_FLAGS: ${{ inputs.apply_flags }}
+          HETZNER_PUBLIC_KEY: ${{ env.HCLOUD_PUBLIC_KEY }}

--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -66,3 +66,4 @@ jobs:
           TERRAGRUNT_INCLUDE_DIR: ${{ inputs.tg_include_dir }}
           PLAN_FLAGS: ${{ inputs.plan_flags }}
           TERRAGRUNT_NON_INTERACTIVE: true
+          HETZNER_PUBLIC_KEY: ${{ env.HCLOUD_PUBLIC_KEY }}


### PR DESCRIPTION
This PR fixes an issue from #67. Since the Actions environment variable containing the Hetzner public key was not passed on to Terragrunt, the deployment and planning workflows failed. This PR checks in the changes needed to allow them to pass.
