### PR TITLE
Fix backend server name

### DIFF
--- a/infra/backend/modules/server/main.tf
+++ b/infra/backend/modules/server/main.tf
@@ -9,7 +9,7 @@ resource "hcloud_ssh_key" "main" {
   public_key = var.public_key
 }
 resource "hcloud_server" "backend_server" {
-  name        = "backend_server"
+  name        = "node1"
   image       = "fedora-41"
   server_type = "cpx11"
   location    = "hil-dc1"


### PR DESCRIPTION
The name passed in to the hcloud_server resource cannot contain underscores, as the latest TG deployment [run](https://github.com/nestrr/flock-infra/actions/runs/13444133782) shows. This PR fixes that error by naming it node1 instead.
