### PR TITLE
Fix location passed to backend server resource

### DIFF
--- a/infra/backend/modules/server/main.tf
+++ b/infra/backend/modules/server/main.tf
@@ -12,7 +12,7 @@ resource "hcloud_server" "backend_server" {
   name        = "node1"
   image       = "fedora-41"
   server_type = "cpx11"
-  location    = "hil-dc1"
+  location    = "hil"
   public_net {
     ipv4_enabled = true
     ipv6_enabled = true


### PR DESCRIPTION
This PR fixes the location name passed to the hcloud_server resource. It should have been the location 'hil', not the datacenter name 'hil-dc1'.
