### PR TITLE
Create Terragrunt units to support frontend prod deployment

### DIFF
--- a/infra/frontend/live/prod/env.hcl
+++ b/infra/frontend/live/prod/env.hcl
@@ -1,0 +1,4 @@
+locals {
+  environment = "prod"
+  production  = true
+}

--- a/infra/frontend/live/prod/oidc/terragrunt.hcl
+++ b/infra/frontend/live/prod/oidc/terragrunt.hcl
@@ -1,0 +1,45 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform and OpenTofu that helps keep your code DRY and
+# maintainable: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Include the root `terragrunt.hcl` configuration. The root configuration contains settings that are common across all
+# components and environments, such as how to configure remote state.
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+# Include the common configuration for the component. The common configuration contains settings that are common
+# for the component across all environments.
+include "common" {
+  path = "${dirname(find_in_parent_folders("root.hcl"))}/frontend/live/common/oidc.hcl"
+  # We want to reference the variables from the included config in this configuration, so we expose it.
+  expose = true
+}
+# Create feature so that resource creation is only enabled if this feature is explicitly set to true.
+feature "create_oidc_resources" {
+  default = false
+}
+# Create feature so that change runs are only enabled if this feature is explicitly set to true.
+feature "run_changes" {
+  default = false
+}
+# Configure the version of the module to use in this environment. This allows you to promote new versions one
+# environment at a time (e.g., qa -> stage -> prod).
+terraform {
+  source = "${include.common.locals.base_source_url}?ref=v0.1.0-beta.35"
+  before_hook "prevent_creation" {
+    commands = ["apply", "destroy", "plan"]
+    execute  = feature.run_changes.value ? ["bash", "-c", "echo 'Creating resources.'"] : ["bash", "-c", "echo 'Modifying OIDC setup is skipped, as run_changes feature is set to false.' && exit 1"]
+  }
+}
+# Exclude this unit from run queue if run-all is being used
+exclude {
+    if = !feature.run_changes.value
+    actions = ["apply", "destroy", "plan"]
+}
+
+inputs = {
+  enable_resource_creation = feature.create_oidc_resources.value
+}

--- a/infra/frontend/live/prod/service_token/terragrunt.hcl
+++ b/infra/frontend/live/prod/service_token/terragrunt.hcl
@@ -1,0 +1,42 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform and OpenTofu that helps keep your code DRY and
+# maintainable: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Include the root `terragrunt.hcl` configuration. The root configuration contains settings that are common across all
+# components and environments, such as how to configure remote state.
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+# Include the common configuration for the component. The common configuration contains settings that are common
+# for the component across all environments.
+include "common" {
+  path = "${dirname(find_in_parent_folders("root.hcl"))}/frontend/live/common/service_token.hcl"
+  # We want to reference the variables from the included config in this configuration, so we expose it.
+  expose = true
+}
+
+# Create feature so that service token is only modified if this feature is explicitly set to true.
+feature "modify_service_token" {
+  default = false
+}
+
+# Configure the version of the module to use in this environment. This allows you to promote new versions one
+# environment at a time (e.g., qa -> stage -> prod).
+terraform {
+  source = "${include.common.locals.base_source_url}?ref=${get_env("LATEST_RELEASE_TAG", "")}"
+  before_hook "prevent_mod_token" {
+    commands = ["apply", "destroy", "plan"]
+    execute  = feature.modify_service_token.value ? ["bash", "-c", "echo 'Modifying service token.'"] : ["bash", "-c", "echo 'Modifying service token is skipped, as modify_service_token feature is set to false.' && exit 1"]
+  }
+}
+
+# Exclude this unit from run queue if run-all is being used
+exclude {
+    if = !feature.modify_service_token.value
+    actions = ["apply", "destroy", "plan"]
+}
+
+# No inputs specified, as all are determined by includes.

--- a/infra/frontend/live/prod/web_app/terragrunt.hcl
+++ b/infra/frontend/live/prod/web_app/terragrunt.hcl
@@ -17,17 +17,6 @@ include "common" {
   # We want to reference the variables from the included config in this configuration, so we expose it.
   expose = true
 }
-# BUG: Terraform provider for Vercel fails to update environment variables resource properly.
-# @see https://github.com/vercel/terraform-provider-vercel/issues/262
-# The deploy feature is a temporary workaround to exclude web app infra deployments until Vercel's provider fixes this issue.
-feature "deploy" {
-  default = "false"
-}
-
-exclude {
-  if      = !feature.deploy.value
-  actions = ["apply", "destroy", "plan"]
-}
 
 # Configure the version of the module to use in this environment. This allows you to promote new versions one
 # environment at a time (e.g., qa -> stage -> prod).


### PR DESCRIPTION
Per FLOC-62, this PR creates the terragrunt units necessary to support frontend production deployments.
